### PR TITLE
Srch 0000 Disable scrapyd UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: Run tests
           command: |
             . venv/bin/activate
-            python -m pytest tests --ignore=tests/integration_tests/
+            python -m pytest tests
 
 workflows:
   version: 2

--- a/search_gov_crawler/scrapy.cfg
+++ b/search_gov_crawler/scrapy.cfg
@@ -4,7 +4,8 @@
 # https://scrapyd.readthedocs.io/en/latest/deploy.html
 
 [settings]
-default = search_gov_spiders.settings
+search_gov_spiders = search_gov_spiders.settings
+default = %(search_gov_spiders)s
 
 [deploy:local]
 url = http://localhost:6800/

--- a/search_gov_crawler/scrapyd.conf
+++ b/search_gov_crawler/scrapyd.conf
@@ -19,7 +19,8 @@ jobstorage  = scrapyd.jobstorage.SqliteJobStorage
 application = search_gov_crawler.search_gov_scrapyd.scrapyd_app
 launcher    = scrapyd.launcher.Launcher
 spiderqueue = scrapyd.spiderqueue.SqliteSpiderQueue
-webroot     = scrapyd.website.Root
+webroot     = search_gov_crawler.search_gov_scrapyd.DisabledUIRoot
+#webroot     = scrapyd.website.Root <-- old webroot, revert once UI is allowed
 eggstorage  = scrapyd.eggstorage.FilesystemEggStorage
 
 [services]

--- a/search_gov_crawler/search_gov_scrapyd/__init__.py
+++ b/search_gov_crawler/search_gov_scrapyd/__init__.py
@@ -6,15 +6,18 @@ scrapyd.conf file.  Run scrapyd as normal on the command line.
 import sys
 
 from twisted.logger import jsonFileLogObserver, LogLevelFilterPredicate, FilteringLogObserver, LogLevel, ILogObserver
-
+from twisted.web import resource
 from scrapyd.app import application
+from scrapyd import website
 
 
 def scrapyd_app(config):
+    """Customized app entry point referenced in scrapydconfig that allows for json logging."""
+
     log_observer = FilteringLogObserver(
-        observer=jsonFileLogObserver(sys.stdout),
+        observer=jsonFileLogObserver(sys.stdout),  # type: ignore
         predicates=[
-            LogLevelFilterPredicate(LogLevel.info),
+            LogLevelFilterPredicate(LogLevel.info),  # type: ignore
         ],
     )
 
@@ -22,3 +25,31 @@ def scrapyd_app(config):
     app.setComponent(ILogObserver, log_observer)
 
     return app
+
+
+class DisabledUIRoot(website.Root):
+    """
+    Customized website root resource that disables existing UI by extending built-in root and
+    making the changes we need.
+    """
+
+    def __init__(self, config, app):
+        super().__init__(config, app)
+        print(self.listEntities())
+        self.delEntity(b"")
+        self.delEntity(b"jobs")
+        self.delEntity(b"items")
+        self.delEntity(b"logs")
+        self.putChild(b"", DisabledUIHome(self))  # type: ignore
+
+
+class DisabledUIHome(resource.Resource):
+    """Replace home resource, i.e. 'http://scrapyd.server.address/' with a empty response."""
+
+    def __init__(self, root):
+        super().__init__()
+        self.root = root
+
+    def render_GET(self, request):  # pylint: disable=invalid-name
+        request.setResponseCode(200)
+        return b""

--- a/search_gov_crawler/search_gov_scrapyd/__init__.py
+++ b/search_gov_crawler/search_gov_scrapyd/__init__.py
@@ -35,7 +35,6 @@ class DisabledUIRoot(website.Root):
 
     def __init__(self, config, app):
         super().__init__(config, app)
-        print(self.listEntities())
         self.delEntity(b"")
         self.delEntity(b"jobs")
         self.delEntity(b"items")

--- a/tests/integration_tests/scrapy.cfg
+++ b/tests/integration_tests/scrapy.cfg
@@ -1,6 +1,0 @@
-[settings]
-default = search_gov_spiders.settings
-
-[deploy:local]
-url = http://localhost:6800/
-project = search_gov_spiders

--- a/tests/integration_tests/scrapy.cfg
+++ b/tests/integration_tests/scrapy.cfg
@@ -1,0 +1,6 @@
+[settings]
+default = search_gov_spiders.settings
+
+[deploy:local]
+url = http://localhost:6800/
+project = search_gov_spiders

--- a/tests/integration_tests/test_scrapyd.py
+++ b/tests/integration_tests/test_scrapyd.py
@@ -25,12 +25,14 @@ class TestScrapyd:
 
     @pytest.fixture(scope="class", name="scrapyd_cwd")
     def fixture_scrapyd_cwd(self) -> Path:
+        print(f"CWD - {Path(Path(__file__).parent.parent.parent / "search_gov_crawler").resolve()}")
         return Path(Path(__file__).parent.parent.parent / "search_gov_crawler").resolve()
 
     @pytest.fixture(scope="class", name="scrapyd_env")
     def fixture_scrapyd_env(self) -> dict:
         scrapyd_env = os.environ.copy()
         scrapyd_env["PYTHONPATH"] = str(Path(__file__).parent.parent.parent.resolve())
+        print(f"ENV - {str(Path(__file__).parent.parent.parent.resolve())}")
         return scrapyd_env
 
     @pytest.fixture(scope="class", name="scrapyd_process")

--- a/tests/integration_tests/test_scrapyd.py
+++ b/tests/integration_tests/test_scrapyd.py
@@ -25,6 +25,7 @@ class TestScrapyd:
 
     @pytest.fixture(scope="class", name="scrapyd_cwd")
     def fixture_scrapyd_cwd(self) -> Path:
+        print(f"ROOT - {Path(__file__)}")
         print(f"CWD - {Path(Path(__file__).parent.parent.parent / "search_gov_crawler").resolve()}")
         return Path(Path(__file__).parent.parent.parent / "search_gov_crawler").resolve()
 

--- a/tests/integration_tests/test_scrapyd.py
+++ b/tests/integration_tests/test_scrapyd.py
@@ -45,11 +45,15 @@ class TestScrapyd:
     def fixture_scrapyd_client(self, scrapyd_process) -> ScrapydClient:  # pylint: disable=unused-argument
         return ScrapydClient()
 
-    def test_scrapyd_list_projects(self, scrapyd_client):
-        assert scrapyd_client.projects() == ["search_gov_spiders", "default"]
+    @pytest.fixture(scope="class", name="scrapyd_project", params=["default", "search_gov_spiders"])
+    def fixture_scrapyd_project(self, request):
+        return request.param
 
-    def test_scrapyd_list_spiders(self, scrapyd_client):
-        assert scrapyd_client.spiders(project="default") == ["domain_spider", "domain_spider_js"]
+    def test_scrapyd_list_projects(self, scrapyd_client, scrapyd_project):
+        assert scrapyd_project in scrapyd_client.projects()
+
+    def test_scrapyd_list_spiders(self, scrapyd_client, scrapyd_project):
+        assert scrapyd_client.spiders(project=scrapyd_project) == ["domain_spider", "domain_spider_js"]
 
     @pytest.fixture(scope="class", name="temp_egg_file")
     def fixture_temp_egg_file(self, temp_egg_dir):

--- a/tests/integration_tests/test_scrapyd.py
+++ b/tests/integration_tests/test_scrapyd.py
@@ -40,7 +40,6 @@ class TestScrapyd:
     def fixture_scrapyd_process(self, scrapyd_cwd, scrapyd_env):
         with subprocess.Popen(["scrapyd"], cwd=scrapyd_cwd, env=scrapyd_env) as scrapyd_process:
             time.sleep(1)
-            print(subprocess.getoutput("ps aux | grep scrapyd"))
             yield scrapyd_process
             scrapyd_process.kill()
             Path(scrapyd_cwd / "twistd.pid").unlink(missing_ok=True)
@@ -50,10 +49,10 @@ class TestScrapyd:
         return ScrapydClient()
 
     def test_scrapyd_list_projects(self, scrapyd_client):
-        assert scrapyd_client.projects() == ["search_gov_spiders", "default"]
+        assert "default" in scrapyd_client.projects()  # == ["search_gov_spiders", "default"]
 
     def test_scrapyd_list_spiders(self, scrapyd_client):
-        assert scrapyd_client.spiders(project="search_gov_spiders") == ["domain_spider", "domain_spider_js"]
+        assert scrapyd_client.spiders(project="default") == ["domain_spider", "domain_spider_js"]
 
     @pytest.fixture(scope="class", name="temp_egg_file")
     def fixture_temp_egg_file(self, temp_egg_dir):

--- a/tests/integration_tests/test_scrapyd.py
+++ b/tests/integration_tests/test_scrapyd.py
@@ -25,15 +25,12 @@ class TestScrapyd:
 
     @pytest.fixture(scope="class", name="scrapyd_cwd")
     def fixture_scrapyd_cwd(self) -> Path:
-        print(f"ROOT - {Path(__file__)}")
-        print(f"CWD - {Path(Path(__file__).parent.parent.parent / "search_gov_crawler").resolve()}")
         return Path(Path(__file__).parent.parent.parent / "search_gov_crawler").resolve()
 
     @pytest.fixture(scope="class", name="scrapyd_env")
     def fixture_scrapyd_env(self) -> dict:
         scrapyd_env = os.environ.copy()
         scrapyd_env["PYTHONPATH"] = str(Path(__file__).parent.parent.parent.resolve())
-        print(f"ENV - {str(Path(__file__).parent.parent.parent.resolve())}")
         return scrapyd_env
 
     @pytest.fixture(scope="class", name="scrapyd_process")
@@ -49,7 +46,7 @@ class TestScrapyd:
         return ScrapydClient()
 
     def test_scrapyd_list_projects(self, scrapyd_client):
-        assert "default" in scrapyd_client.projects()  # == ["search_gov_spiders", "default"]
+        assert scrapyd_client.projects() == ["search_gov_spiders", "default"]
 
     def test_scrapyd_list_spiders(self, scrapyd_client):
         assert scrapyd_client.spiders(project="default") == ["domain_spider", "domain_spider_js"]

--- a/tests/integration_tests/test_scrapyd.py
+++ b/tests/integration_tests/test_scrapyd.py
@@ -40,6 +40,7 @@ class TestScrapyd:
     def fixture_scrapyd_process(self, scrapyd_cwd, scrapyd_env):
         with subprocess.Popen(["scrapyd"], cwd=scrapyd_cwd, env=scrapyd_env) as scrapyd_process:
             time.sleep(1)
+            print(subprocess.getoutput("ps aux | grep scrapyd"))
             yield scrapyd_process
             scrapyd_process.kill()
             Path(scrapyd_cwd / "twistd.pid").unlink(missing_ok=True)

--- a/tests/integration_tests/test_scrapyd.py
+++ b/tests/integration_tests/test_scrapyd.py
@@ -25,7 +25,7 @@ class TestScrapyd:
 
     @pytest.fixture(scope="class", name="scrapyd_cwd")
     def fixture_scrapyd_cwd(self) -> Path:
-        return Path(__file__).parent.parent.parent / "search_gov_crawler"
+        return Path(Path(__file__).parent.parent.parent / "search_gov_crawler").resolve()
 
     @pytest.fixture(scope="class", name="scrapyd_env")
     def fixture_scrapyd_env(self) -> dict:


### PR DESCRIPTION
## Summary
- Add new website root to scrapyd with `/`, `/jobs`, `/items`, and `/logs` removed.  Replaced `/` with a blank response and 200 status code.
  - Added integration tests to confirm these pages don't work.
- Fixed integration test so they can run in circle, it was a `PYTHONPATH` issue while running the `subprocess` command.


### Testing
- Start scrapyd (from `search_gov_crawlers` dir)
- Confirm any GET requests to `http://localhost:6800/` returns a blank response and a 200.
- Confirm any requests to the following endpoints return 404 messages:
  - `http://localhost:6800/jobs`
  - `http://localhost:6800/items`
  - `http://localhost:6800/logs`
- Confirm some/all/any of the web services still work:
  - `http://localhost:6800/daemonstatus.json`
  - `http://localhost:6800/listprojects.json`
  - `http://localhost:6800/listspiders.json?project=search_gov_spiders`
  - `http://localhost:6800/listversions.json?project=search_gov_spiders`
  - `http://localhost:6800/listjobs.json?project=search_gov_spiders`
  - 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [ ] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer".
