### PR TITLE
SRCH-5588 Scrapy Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Make sure to run `pip install -r requirements.txt` and `playwright install` befo
             # deploy production
             scrapyd-deploy production
 
-4. For an interface to view jobs (pending, running, finished) and logs, access http://localhost:6800/. However, to actually manipulate the spiders deployed to the Scrapyd server, you'll need to use the [Scrapyd JSON API](https://scrapyd.readthedocs.io/en/latest/api.html).
+4. For an interface to view jobs (pending, running, finished) and logs, access http://localhost:6800/. However, to actually manipulate the spiders deployed to the Scrapyd server, you'll need to use the [*Scrapyd JSON API*](https://scrapyd.readthedocs.io/en/latest/api.html).
 
     Some most-used commands:
 
@@ -136,19 +136,29 @@ Make sure to run `pip install -r requirements.txt` and `playwright install` befo
 
 ## Adding new spiders
 
-1.  Navigate to anywhere within the [*Scrapy project root *](search_gov_crawler) directory and run this command:
+1.  Navigate to anywhere within the [*Scrapy project root*](search_gov_crawler) directory and run this command:
 
         $ scrapy genspider -t crawl <spider_name> "<spider_starting_domain>"
 
 2. Open the `/search_gov_spiders/search_gov_spiders/spiders/boilerplate.py` file and replace the lines of the generated spider with the lines of the boilerplate spider as dictated in the boilerplate file.
 
-3. Modify the `rules` in the new spider as needed. Here's the [Scrapy rules documentation](https://docs.scrapy.org/en/latest/topics/spiders.html#crawling-rules) for the specifics.
+3. Modify the `rules` in the new spider as needed. Here's the [*Scrapy rules documentation*](https://docs.scrapy.org/en/latest/topics/spiders.html#crawling-rules) for the specifics.
 
 4. To update the Scrapyd server with the new spider, run:
 
         $ scrapyd-deploy <default or endpoint_name>
 
         ## Running Against All Listed Search.gov Domains
+
+## Running scrapy scheduler
+This process allows for scrapy to be run directly using an in-memory scheduler.  The schedule is based on the initial schedule setup in the [*utility files readme*](search_gov_crawler/search_gov_spiders/utility_files/README.md#job-schedule-calendar).  The process will run until killed.
+
+0. Source virtual environment and update dependencies.
+
+1. Start scheduler
+
+        $ python search_gov_crawler/scrapy_scheduler.py
+
 
 ## Running Scrapydweb UI
 

--- a/search_gov_crawler/scrapy_scheduler.py
+++ b/search_gov_crawler/scrapy_scheduler.py
@@ -89,7 +89,7 @@ def start_scrapy_scheduler(input_file: Path) -> None:
     # Initalize scheduler
     scheduler = BlockingScheduler(
         jobstores={"memory": MemoryJobStore()},
-        executors={"default": ThreadPoolExecutor(max_workers=5)},
+        executors={"default": ThreadPoolExecutor(max_workers=10)},
         job_defaults={"coalesce": False, "max_instances": 1},
         timezone="UTC",
     )

--- a/search_gov_crawler/scrapy_scheduler.py
+++ b/search_gov_crawler/scrapy_scheduler.py
@@ -1,0 +1,106 @@
+import json
+import logging
+import subprocess
+import os
+from pathlib import Path
+
+from apscheduler.executors.pool import ThreadPoolExecutor
+from apscheduler.jobstores.memory import MemoryJobStore
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apscheduler.triggers.cron import CronTrigger
+from pythonjsonlogger.json import JsonFormatter
+
+from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
+from search_gov_crawler.search_gov_spiders.utility_files.init_schedule import SpiderSchedule
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger()
+log.handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
+
+CRAWL_SITES_FILE = Path(__file__).parent / "search_gov_spiders" / "utility_files" / "crawl-sites.json"
+
+
+def run_scrapy_crawl(spider: str, allowed_domains: str, start_urls: str) -> None:
+    """Runs `scrapy crawl` command as a subprocess given the allowed arguments"""
+
+    scrapy_env = os.environ.copy()
+    scrapy_env["PYTHONPATH"] = str(Path(__file__).parent.parent)
+
+    subprocess.run(
+        f"scrapy crawl {spider} -a allowed_domains={allowed_domains} -a start_urls={start_urls}",
+        check=True,
+        cwd=Path(__file__).parent,
+        env=scrapy_env,
+        executable="/bin/bash",
+        shell=True,
+    )
+    log.info(
+        "Successfully completed scrapy crawl with args spider=%s, allowed_domains=%s, start_urls=%s",
+        spider,
+        allowed_domains,
+        start_urls,
+    )
+
+
+def transform_crawl_sites(crawl_sites: list[dict]) -> list[dict]:
+    """Transform crawl sites records into a format that can be used to"""
+
+    transformed_crawl_sites = []
+    schedule = SpiderSchedule()
+
+    for crawl_site in crawl_sites:
+        job_name = str(crawl_site["name"])
+        schedule_slot = schedule.get_next_slot()
+        transformed_crawl_sites.append(
+            {
+                "func": run_scrapy_crawl,
+                "id": job_name.lower().replace(" ", "-").replace("---", "-"),
+                "name": job_name,
+                "trigger": CronTrigger(
+                    year="*",
+                    month="*",
+                    day="*",
+                    week="*",
+                    day_of_week=schedule_slot.day,
+                    hour=schedule_slot.hour,
+                    minute=schedule_slot.minute,
+                    second=0,
+                    timezone="UTC",
+                    jitter=0,
+                ),
+                "args": [
+                    "domain_spider" if not crawl_site["handle_javascript"] else "domain_spider_js",
+                    crawl_site["allowed_domains"],
+                    crawl_site["starting_urls"],
+                ],
+            }
+        )
+
+    return transformed_crawl_sites
+
+
+def start_scrapy_scheduler(input_file: Path) -> None:
+    """Initializes schedule from input file, schedules jobs and runs scheduler"""
+
+    # Load and transform crawl sites
+    crawl_sites = json.loads(input_file.read_text(encoding="UTF-8"))
+    apscheduler_jobs = transform_crawl_sites(crawl_sites)
+
+    # Initalize scheduler
+    scheduler = BlockingScheduler(
+        jobstores={"memory": MemoryJobStore()},
+        executors={"default": ThreadPoolExecutor(max_workers=5)},
+        job_defaults={"coalesce": False, "max_instances": 1},
+        timezone="UTC",
+    )
+
+    # Schedule Jobs
+    for apscheduler_job in apscheduler_jobs:
+        scheduler.add_job(**apscheduler_job, jobstore="memory")
+
+    # Run Scheduler
+    scheduler.start()
+
+
+if __name__ == "__main__":
+    start_scrapy_scheduler(input_file=CRAWL_SITES_FILE)

--- a/tests/search_gov_spiders/test_scrapy_scheduler.py
+++ b/tests/search_gov_spiders/test_scrapy_scheduler.py
@@ -1,0 +1,121 @@
+import subprocess
+
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.schedulers.blocking import BlockingScheduler
+from search_gov_crawler.scrapy_scheduler import run_scrapy_crawl, transform_crawl_sites, start_scrapy_scheduler
+
+
+def test_run_scrapy_crawl(caplog, monkeypatch):
+    def mock_run(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    with caplog.at_level("INFO"):
+        run_scrapy_crawl("test_spider", "test-domain.example.com", "http://starting-url.example.com/")
+
+    assert (
+        "Successfully completed scrapy crawl with args spider=test_spider, "
+        "allowed_domains=test-domain.example.com, start_urls=http://starting-url.example.com/"
+    ) in caplog.messages
+
+
+def test_transform_crawl_sites(crawl_sites_test_file_json):
+    transformed_crawl_sites = transform_crawl_sites(crawl_sites_test_file_json)
+
+    # CronTrigger class does not implement __eq__
+    triggers = [str(site.pop("trigger")) for site in transformed_crawl_sites]
+    assert triggers == [
+        str(
+            CronTrigger(
+                year="*",
+                month="*",
+                day="*",
+                week="*",
+                day_of_week="mon",
+                hour="03",
+                minute="30",
+                second=0,
+                timezone="UTC",
+                jitter=0,
+            )
+        ),
+        str(
+            CronTrigger(
+                year="*",
+                month="*",
+                day="*",
+                week="*",
+                day_of_week="mon",
+                hour="05",
+                minute="30",
+                second=0,
+                timezone="UTC",
+                jitter=0,
+            )
+        ),
+        str(
+            CronTrigger(
+                year="*",
+                month="*",
+                day="*",
+                week="*",
+                day_of_week="mon",
+                hour="07",
+                minute="30",
+                second=0,
+                timezone="UTC",
+                jitter=0,
+            ),
+        ),
+        str(
+            CronTrigger(
+                year="*",
+                month="*",
+                day="*",
+                week="*",
+                day_of_week="mon",
+                hour="09",
+                minute="30",
+                second=0,
+                timezone="UTC",
+                jitter=0,
+            ),
+        ),
+    ]
+
+    assert transformed_crawl_sites == [
+        {
+            "func": run_scrapy_crawl,
+            "id": "quotes-1",
+            "name": "Quotes 1",
+            "args": ["domain_spider", "quotes.toscrape.com", "https://quotes.toscrape.com/"],
+        },
+        {
+            "func": run_scrapy_crawl,
+            "id": "quotes-2",
+            "name": "Quotes 2",
+            "args": ["domain_spider_js", "quotes.toscrape.com", "https://quotes.toscrape.com/js/"],
+        },
+        {
+            "func": run_scrapy_crawl,
+            "id": "quotes-3",
+            "name": "Quotes 3",
+            "args": ["domain_spider_js", "quotes.toscrape.com", "https://quotes.toscrape.com/js-delayed/"],
+        },
+        {
+            "func": run_scrapy_crawl,
+            "id": "quotes-4",
+            "name": "Quotes 4",
+            "args": ["domain_spider", "quotes.toscrape.com/tag/", "https://quotes.toscrape.com/"],
+        },
+    ]
+
+
+def test_start_scrapy_scheduler(caplog, monkeypatch, crawl_sites_test_file):
+    monkeypatch.setattr(BlockingScheduler, "start", lambda x: True)
+
+    with caplog.at_level("INFO"):
+        start_scrapy_scheduler(input_file=crawl_sites_test_file)
+
+    assert len(caplog.messages) == 4
+    assert "Adding job tentatively -- it will be properly scheduled when the scheduler starts" in caplog.messages


### PR DESCRIPTION
## Summary
- Allows for apscheduler-backed process to schedule and run `scrapy crawl` commands directly, without scrapyd or scrapydweb.  This approach does not add any new requirements nor does it break anything related to running scrapyd or scrapydweb.
- Updated readme and added a few basic tests.

### Testing
- Follow directions in main readme to start scheduler.  This will schedule all jobs according the the initial schedule specified in the [utilitiy files readme schedule](https://github.com/GSA/searchgov-spider/blob/main/search_gov_crawler/search_gov_spiders/utility_files/README.md#job-schedule-calendar). 
- You can now wait for the next scheduled run to ensure things work.

- If you don't want to wait you can try to schedule some test crawls by editing the `scrapy_scheduler.py` file to load crawl sites from the test sites file.  It will schedule the jobs 2, 4, and 6 minutes in the future. You can then watch the runs and monitor the output.
  - Replace `CRAWL_SITES_FILE` assignment on line 20 with `CRAWL_SITES_FILE = Path(__file__).parent.parent / "tests" / "search_gov_spiders" / "crawl-sites-test.json"`

  - Replace the entire `transform_crawl_sites` function with the code below. 
```python
def transform_crawl_sites(crawl_sites: list[dict]) -> list[dict]:
    """Transform crawl sites records into a format that can be used to"""

    transformed_crawl_sites = []
    schedule = SpiderSchedule()

    from datetime import datetime, UTC, timedelta

    current_datetime = datetime.now(tz=UTC)
    for idx, crawl_site in enumerate(crawl_sites):
        job_name = str(crawl_site["name"])
        schedule_slot = schedule.get_next_slot()

        next_run = current_datetime + timedelta(minutes=idx + 2)

        transformed_crawl_sites.append(
            {
                "func": run_scrapy_crawl,
                "id": job_name.lower().replace(" ", "-").replace("---", "-"),
                "name": job_name,
                "trigger": CronTrigger(
                    year="*",
                    month="*",
                    day="*",
                    week="*",
                    day_of_week=next_run.strftime("%a").lower(),
                    hour=next_run.hour,
                    minute=next_run.minute,
                    second=0,
                    timezone="UTC",
                    jitter=0,
                ),
                "args": [
                    "domain_spider" if not crawl_site["handle_javascript"] else "domain_spider_js",
                    crawl_site["allowed_domains"],
                    crawl_site["starting_urls"],
                ],
            }
        )

    return transformed_crawl_sites
```
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
