### PR TITLE
SRCH-5678 update max_workers

### DIFF
--- a/search_gov_crawler/scrapy_scheduler.py
+++ b/search_gov_crawler/scrapy_scheduler.py
@@ -87,9 +87,11 @@ def start_scrapy_scheduler(input_file: Path) -> None:
     apscheduler_jobs = transform_crawl_sites(crawl_sites)
 
     # Initalize scheduler
+    max_workers = min(32, (os.cpu_count() or 1) + 4)  # default from concurrent.futures
+
     scheduler = BlockingScheduler(
         jobstores={"memory": MemoryJobStore()},
-        executors={"default": ThreadPoolExecutor(max_workers=10)},
+        executors={"default": ThreadPoolExecutor(max_workers)},
         job_defaults={"coalesce": False, "max_instances": 1},
         timezone="UTC",
     )


### PR DESCRIPTION
## Summary
- After the discussion on #48 and running some more tests locally, I think we should update the max workers for the threadpool to be the module default for concurrent.futures.  Apscheduler forces this to be 10 and while I could have subclassed the ThreadPoolExecutor class to add this custom __init__ method, i thought it more clear to hard code the latest default value here.  See https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor for details.
- Locally, this changes values from 10 to 16 and I noticed a **big** difference in performance.
- This line is executed in unit tests but you can also run the scheduler using any of the methods in #48 

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
