### PR TITLE
SRCH-5714 add ability to do a single benchmark run

### DIFF
--- a/search_gov_crawler/benchmark.py
+++ b/search_gov_crawler/benchmark.py
@@ -1,0 +1,68 @@
+import argparse
+import logging
+import time
+import os
+from datetime import datetime, UTC, timedelta
+
+from apscheduler.executors.pool import ThreadPoolExecutor
+from apscheduler.jobstores.memory import MemoryJobStore
+from apscheduler.schedulers.background import BackgroundScheduler
+from pythonjsonlogger.json import JsonFormatter
+
+from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
+from search_gov_crawler import scrapy_scheduler
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger()
+log.handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
+
+
+def benchmark_scrapy(allowed_domains: str, starting_urls: str, handle_javascript: bool, runtime_offset_seconds: int):
+    """Function to allow for benchmarking jobs"""
+
+    # Initalize scheduler
+    max_workers = min(32, (os.cpu_count() or 1) + 4)  # default from concurrent.futures
+
+    scheduler = BackgroundScheduler(
+        jobstores={"memory": MemoryJobStore()},
+        executors={"default": ThreadPoolExecutor(max_workers)},
+        job_defaults={"coalesce": False, "max_instances": 1},
+        timezone="UTC",
+    )
+
+    job_name = f"benchmark - {starting_urls}"
+
+    apscheduler_job = {
+        "func": scrapy_scheduler.run_scrapy_crawl,
+        "id": job_name.lower().replace(" ", "-").replace("---", "-"),
+        "name": job_name,
+        "next_run_time": datetime.now(tz=UTC) + timedelta(seconds=runtime_offset_seconds),
+        "args": [
+            "domain_spider" if not handle_javascript else "domain_spider_js",
+            allowed_domains,
+            starting_urls,
+        ],
+    }
+    scheduler.add_job(**apscheduler_job, jobstore="memory")
+
+    scheduler.start()
+    time.sleep(runtime_offset_seconds + 2)
+    scheduler.shutdown()  # wait until all jobs are finished
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run a scrapy schedule or benchmark based on input.")
+    parser.add_argument("-d", "--allowed_domains", type=str, help="domains allowed to crawl", required=True)
+    parser.add_argument("-u", "--starting_urls", type=str, help="url used to start crawl", required=True)
+    parser.add_argument("-js", "--handle_js", action=argparse.BooleanOptionalAction, help="Flag to enable javascript")
+    parser.add_argument("-t", "--runtime_offset", type=int, default=5, help="Number of seconds to offset job start")
+    args = parser.parse_args()
+
+    log.info("***RUNNING BENCHMARK TEST***")
+    benchmark_args = {
+        "allowed_domains": args.allowed_domains,
+        "starting_urls": args.starting_urls,
+        "handle_javascript": args.handle_js,
+        "runtime_offset_seconds": args.runtime_offset,
+    }
+    benchmark_scrapy(**benchmark_args)

--- a/search_gov_crawler/scrapy_scheduler.py
+++ b/search_gov_crawler/scrapy_scheduler.py
@@ -1,11 +1,15 @@
+import argparse
 import json
 import logging
 import subprocess
+import time
 import os
+from datetime import datetime, UTC, timedelta
 from pathlib import Path
 
 from apscheduler.executors.pool import ThreadPoolExecutor
 from apscheduler.jobstores.memory import MemoryJobStore
+from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
 from pythonjsonlogger.json import JsonFormatter
@@ -17,6 +21,7 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
 log.handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
 
+BENCHMARK_RUN = bool(os.environ.get("BENCHMARK_RUN", "False").lower() == "true")
 CRAWL_SITES_FILE = Path(__file__).parent / "search_gov_spiders" / "utility_files" / "crawl-sites.json"
 
 
@@ -104,5 +109,55 @@ def start_scrapy_scheduler(input_file: Path) -> None:
     scheduler.start()
 
 
+def benchmark_scrapy(allowed_domains: str, starting_urls: str, handle_javascript: bool, runtime_offset_seconds: int):
+    """Function to allow for benchmarking jobs"""
+
+    # Initalize scheduler
+    max_workers = min(32, (os.cpu_count() or 1) + 4)  # default from concurrent.futures
+
+    scheduler = BackgroundScheduler(
+        jobstores={"memory": MemoryJobStore()},
+        executors={"default": ThreadPoolExecutor(max_workers)},
+        job_defaults={"coalesce": False, "max_instances": 1},
+        timezone="UTC",
+    )
+
+    job_name = f"benchmark - {starting_urls}"
+
+    apscheduler_job = {
+        "func": run_scrapy_crawl,
+        "id": job_name.lower().replace(" ", "-").replace("---", "-"),
+        "name": job_name,
+        "next_run_time": datetime.now(tz=UTC) + timedelta(seconds=runtime_offset_seconds),
+        "args": [
+            "domain_spider" if not handle_javascript else "domain_spider_js",
+            allowed_domains,
+            starting_urls,
+        ],
+    }
+    scheduler.add_job(**apscheduler_job, jobstore="memory")
+
+    scheduler.start()
+    time.sleep(runtime_offset_seconds + 2)
+    scheduler.shutdown()  # wait until all jobs are finished
+
+
 if __name__ == "__main__":
-    start_scrapy_scheduler(input_file=CRAWL_SITES_FILE)
+    if not BENCHMARK_RUN:
+        start_scrapy_scheduler(input_file=CRAWL_SITES_FILE)
+    else:
+        parser = argparse.ArgumentParser(description="Run a scrapy schedule or benchmark based on input.")
+        parser.add_argument("--allowed_domains", type=str, help="domains allowed to crawl", required=True)
+        parser.add_argument("--starting_urls", type=str, help="url used to start crawl", required=True)
+        parser.add_argument("--handle_js", action=argparse.BooleanOptionalAction, help="Flag to enable javascript")
+        parser.add_argument("--runtime_offset", type=int, default=5, help="Number of seconds to offset job start")
+        args = parser.parse_args()
+
+        log.info("***RUNNING BENCHMARK TEST***")
+        benchmark_args = {
+            "allowed_domains": args.allowed_domains,
+            "starting_urls": args.starting_urls,
+            "handle_javascript": args.handle_js,
+            "runtime_offset_seconds": args.runtime_offset,
+        }
+        benchmark_scrapy(**benchmark_args)


### PR DESCRIPTION
## Summary
Created this draft PR to help facilitate bench marking... what about something like this? gives us some flexibility?
```

python search_gov_crawler/benchmark.py --starting_urls="https://quotes.toscrape.com" --allowed_domains="quotes.toscrape.com"
```
This will add a job using a similar process as would with the no-UI functionality (and also scrapydweb I think) but we can control what we pass in.

If we need more configurable options we can add more environment variables or add a config file.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [ ] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer".
