### PR TITLE
Srch 5744 benchmark findings

### DIFF
--- a/search_gov_crawler/search_gov_spiders/extensions/json_logging.py
+++ b/search_gov_crawler/search_gov_spiders/extensions/json_logging.py
@@ -11,13 +11,17 @@ from scrapy.signals import spider_opened
 LOG_FMT = "%(asctime)%(name)%(levelname)%(message)"
 
 
-def search_gov_default(obj) -> str | None:
-    """Function to help serialize scrapy objects"""
+def search_gov_default(obj) -> dict | None:
+    """Function to help serialize scrapy objects in logs"""
     if isinstance(obj, Spider):
-        return obj.name
+        return {
+            "name": obj.name,
+            "allowed_domains": getattr(obj, "allowed_domains", None),
+            "start_urls": obj.start_urls,
+        }
 
     if isinstance(obj, Crawler):
-        return str(obj.settings.get("BOT_NAME", "Unknown"))
+        return {"name": str(obj.settings.get("BOT_NAME", "Unknown"))}
 
     return None
 

--- a/search_gov_crawler/search_gov_spiders/middlewares.py
+++ b/search_gov_crawler/search_gov_spiders/middlewares.py
@@ -25,8 +25,8 @@ class MiddlewareBase:
         crawler.signals.connect(s.spider_opened, signal=signals.spider_opened)
         return s
 
-    def spider_opened(self, spider):
-        spider.logger.info(f"Spider opened: {spider.name}")
+    def spider_opened(self, spider):  # pylint: disable=unused-argument
+        ...
 
 
 class SearchGovSpidersSpiderMiddleware(MiddlewareBase):

--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -78,8 +78,7 @@ ITEM_PIPELINES = {
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html
 AUTOTHROTTLE_ENABLED = False
-# The maximum download delay to be set in case of high latencies
-# AUTOTHROTTLE_MAX_DELAY = 5
+
 
 # Enable and configure HTTP caching (disabled by default)
 # HTTPCACHE_ENABLED must be set to false for scrapy playwright to run

--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -10,49 +10,43 @@
 import os
 from datetime import datetime
 
-# Settings for json logging
+# Settings for logging and json logging
 LOG_ENABLED = False
 JSON_LOGGING_ENABLED = True
+LOG_LEVEL = "INFO"
 
 BOT_NAME = "search_gov_spiders"
-
 SPIDER_MODULES = ["search_gov_spiders.spiders"]
 NEWSPIDER_MODULE = "search_gov_spiders.spiders"
 
-# Crawl responsibly by identifying yourself
-# (and your website) on the user-agent
+# Crawl responsibly by identifying yourself (and your website) on the user-agent
 USER_AGENT = "usasearch"
 
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
 
-LOG_LEVEL = "INFO"
+# Disable telnet console since we don't use it
+TELNETCONSOLE_ENABLED = False
 
-# settings for broad crawling
-SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"
-# Configure maximum concurrent requests performed by Scrapy (default: 16)
-# For optimum performance, you should pick a concurrency where
-# CPU usage is at 80-90%.
-CONCURRENT_REQUESTS = 100
-CONCURRENT_REQUESTS_PER_DOMAIN = 100
 COOKIES_ENABLED = False
 REACTOR_THREADPOOL_MAXSIZE = 20
 RETRY_ENABLED = False
 DOWNLOAD_TIMEOUT = 15
+
+# Enforce slow crawling
+CONCURRENT_REQUESTS = 1
+CONCURRENT_REQUESTS_PER_DOMAIN = 1
+DOWNLOAD_DELAY = 1
+
+# settings for broad crawling
+SCHEDULER_PRIORITY_QUEUE = "scrapy.pqueues.DownloaderAwarePriorityQueue"
 # set to True for BFO
 AJAXCRAWL_ENABLED = True
+
 # crawl in BFO order rather than DFO
 DEPTH_PRIORITY = 1
 SCHEDULER_DISK_QUEUE = "scrapy.squeues.PickleFifoDiskQueue"
 SCHEDULER_MEMORY_QUEUE = "scrapy.squeues.FifoMemoryQueue"
-
-
-# Configure a delay for requests for the same website (default: 0)
-# See https://docs.scrapy.org/en/latest/topics/settings.html#download-delay
-# See also autothrottle settings and docs
-DOWNLOAD_DELAY = 0
-# The download delay setting will honor only one of:
-
 
 # Enable or disable spider middlewares
 # See https://docs.scrapy.org/en/latest/topics/spider-middleware.html
@@ -71,11 +65,8 @@ DOWNLOADER_MIDDLEWARES = {
 # See https://docs.scrapy.org/en/latest/topics/extensions.html
 EXTENSIONS = {
     "search_gov_spiders.extensions.json_logging.JsonLogging": -1,
-    "scrapy.extensions.closespider.CloseSpider": 500,
     "spidermon.contrib.scrapy.extensions.Spidermon": 600,
 }
-
-CLOSESPIDER_TIMEOUT_NO_ITEM = 50
 
 # Configure item pipelines
 # See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
@@ -88,7 +79,7 @@ ITEM_PIPELINES = {
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html
 AUTOTHROTTLE_ENABLED = False
 # The maximum download delay to be set in case of high latencies
-AUTOTHROTTLE_MAX_DELAY = 5
+# AUTOTHROTTLE_MAX_DELAY = 5
 
 # Enable and configure HTTP caching (disabled by default)
 # HTTPCACHE_ENABLED must be set to false for scrapy playwright to run
@@ -106,26 +97,17 @@ FEEDS = {
     }
 }
 
-# Playwright Settings
-PLAYWRIGHT_BROWSER_TYPE = "chromium"
-
-PLAYWRIGHT_LAUNCH_OPTIONS = {"headless": True}
-
-DOWNLOAD_HANDLERS = {
-    "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
-    "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
-}
-
+# SPIDERMON SETTINGS
 now = datetime.now()
 date_time = now.today().isoformat()
-dirname= os.path.dirname(__file__)
-body_html_template = os.path.join(dirname, 'actions', 'results.jinja')
+dirname = os.path.dirname(__file__)
+body_html_template = os.path.join(dirname, "actions", "results.jinja")
 
-SPIDERMON_ENABLED = os.environ.get('SPIDERMON_ENABLED', 'False')
+SPIDERMON_ENABLED = os.environ.get("SPIDERMON_ENABLED", "False")
 SPIDERMON_MIN_ITEMS = 1000
 SPIDERMON_TIME_INTERVAL = 1  # time is in seconds
 SPIDERMON_ITEM_COUNT_INCREASE = 100
-SPIDERMON_MAX_EXECUTION_TIME = 86400 
+SPIDERMON_MAX_EXECUTION_TIME = 86400
 SPIDERMON_UNWANTED_HTTP_CODES_MAX_COUNT = 10
 SPIDERMON_UNWANTED_HTTP_CODES = [400, 407, 429, 500, 502, 503, 504, 523, 540, 541]
 SPIDERMON_REPORT_TEMPLATE = "results.jinja"
@@ -133,15 +115,15 @@ SPIDERMON_BODY_HTML_TEMPLATE = body_html_template
 SPIDERMON_REPORT_CONTEXT = {"report_title": "Spidermon File Report"}
 SPIDERMON_REPORT_FILENAME = f"{date_time}_spidermon_file_report.html"
 SPIDERMON_EMAIL_SUBJECT = "Spidermon report"
-SPIDERMON_EMAIL_SENDER = os.environ.get('SPIDERMON_EMAIL_SENDER')
-SPIDERMON_EMAIL_TO = os.environ.get('SPIDERMON_EMAIL_TO')
-SPIDERMON_SMTP_HOST = os.environ.get('SPIDERMON_SMTP_HOST')
-SPIDERMON_SMTP_PORT = os.environ.get('SPIDERMON_SMTP_PORT')
-SPIDERMON_SMTP_USER = os.environ.get('SPIDERMON_SMTP_USER')
-SPIDERMON_SMTP_PASSWORD =  os.environ.get('SPIDERMON_SMTP_PASSWORD')
+SPIDERMON_EMAIL_SENDER = os.environ.get("SPIDERMON_EMAIL_SENDER")
+SPIDERMON_EMAIL_TO = os.environ.get("SPIDERMON_EMAIL_TO")
+SPIDERMON_SMTP_HOST = os.environ.get("SPIDERMON_SMTP_HOST")
+SPIDERMON_SMTP_PORT = os.environ.get("SPIDERMON_SMTP_PORT")
+SPIDERMON_SMTP_USER = os.environ.get("SPIDERMON_SMTP_USER")
+SPIDERMON_SMTP_PASSWORD = os.environ.get("SPIDERMON_SMTP_PASSWORD")
 SPIDERMON_SMTP_ENFORCE_SSL = False
 SPIDERMON_SMTP_ENFORCE_TLS = True
 
 SPIDERMON_PERIODIC_MONITORS = {
-    'search_gov_spiders.monitors.PeriodicMonitorSuite': SPIDERMON_TIME_INTERVAL,
+    "search_gov_spiders.monitors.PeriodicMonitorSuite": SPIDERMON_TIME_INTERVAL,
 }

--- a/search_gov_crawler/search_gov_spiders/spiders/domain_spider_js.py
+++ b/search_gov_crawler/search_gov_spiders/spiders/domain_spider_js.py
@@ -74,10 +74,6 @@ class DomainSpiderJs(CrawlSpider):
             },
             priority="spider",
         )
-        settings.set("CLOSESPIDER_TIMEOUT_NO_ITEM", 50, priority="spider")
-        extensions_settings = settings.getdict("EXTENSIONS")
-        extensions_settings["scrapy.extensions.closespider.CloseSpider"] = 500
-        settings.set("EXTENSIONS", extensions_settings, priority="spider")
 
     def __init__(
         self, *args, allowed_domains: Optional[str] = None, start_urls: Optional[str] = None, **kwargs

--- a/search_gov_crawler/search_gov_spiders/spiders/domain_spider_js.py
+++ b/search_gov_crawler/search_gov_spiders/spiders/domain_spider_js.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
-from scrapy.spiders import CrawlSpider, Rule
 from scrapy.http import Response, Request
+from scrapy.spiders import CrawlSpider, Rule
 
 import search_gov_crawler.search_gov_spiders.helpers.domain_spider as helpers
 from search_gov_crawler.search_gov_spiders.items import SearchGovSpidersItem
@@ -49,7 +49,6 @@ class DomainSpiderJs(CrawlSpider):
     """
 
     name: str = "domain_spider_js"
-    custom_settings: dict = {"PLAYWRIGHT_ABORT_REQUEST": should_abort_request}
     rules = (
         Rule(
             link_extractor=helpers.domain_spider_link_extractor,
@@ -58,6 +57,27 @@ class DomainSpiderJs(CrawlSpider):
             process_request="set_playwright_usage",
         ),
     )
+
+    @classmethod
+    def update_settings(cls, settings):
+        """Moved settings update to this classmethod due to complexity."""
+
+        super().update_settings(settings)
+        settings.set("PLAYWRIGHT_ABORT_REQUEST", should_abort_request, priority="spider")
+        settings.set("PLAYWRIGHT_BROWSER_TYPE", "chromium", priority="spider")
+        settings.set("PLAYWRIGHT_LAUNCH_OPTIONS", {"headless": True}, priority="spider")
+        settings.set(
+            "DOWNLOAD_HANDLERS",
+            {
+                "http": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+                "https": "scrapy_playwright.handler.ScrapyPlaywrightDownloadHandler",
+            },
+            priority="spider",
+        )
+        settings.set("CLOSESPIDER_TIMEOUT_NO_ITEM", 50, priority="spider")
+        extensions_settings = settings.getdict("EXTENSIONS")
+        extensions_settings["scrapy.extensions.closespider.CloseSpider"] = 500
+        settings.set("EXTENSIONS", extensions_settings, priority="spider")
 
     def __init__(
         self, *args, allowed_domains: Optional[str] = None, start_urls: Optional[str] = None, **kwargs

--- a/tests/search_gov_spiders/test_extensions.py
+++ b/tests/search_gov_spiders/test_extensions.py
@@ -18,12 +18,19 @@ from search_gov_crawler.search_gov_spiders.extensions.json_logging import (
 
 class SpiderForTest(Spider):
     def __repr__(self):
-        return self.name
+        return str(
+            {"allowed_domains": getattr(self, "allowed_domains"), "name": self.name, "start_urls": self.start_urls}
+        )
 
 
 HANDLER_TEST_CASES = [
     ("This is a test message!!", "This is a test message!!", None, None),
-    (SpiderForTest(name="handler_test"), "handler_test", SpiderForTest(name="handler_test"), "handler_test"),
+    (
+        SpiderForTest(name="handler_test", allowed_domains="example.com", start_urls="https://www.example.com"),
+        str({"allowed_domains": "example.com", "name": "handler_test", "start_urls": "https://www.example.com"}),
+        SpiderForTest(name="handler_test", allowed_domains="example.com", start_urls="https://www.example.com"),
+        {"allowed_domains": "example.com", "name": "handler_test", "start_urls": "https://www.example.com"},
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
* Made updates and re-organized main `settings.py` so that:
  * Settings adjusting similar high-level behavior are next to each other in the file
  * Commented out a few settings that did not apply because the main flag for that setting is disabled.
  * Disabled the [telnet console](https://docs.scrapy.org/en/latest/topics/telnetconsole.html) since we are not using it, I don't see us starting to use it.  Disabling it likely frees up some memory/CPU that can be used elsewhere.
  * Disabled the close spider extension since I think we want to make sure we crawl every link available and don't want to stop crawling prematurely.
  * Enforced a one second delay between requests and a single concurrent connection.
  * Moved all playwright related settings to the `domain_spider_js` spider to prevent any usage of memory or CPU loading playwrght during non-JS runs as was observed in the benchmark testing.
* Added a more descriptive logging representation of spiders (and crawlers) so that we can identify log messages that belong to different spiders in the same output stream.  Previously you might have seen only `{"spider": "domain_spider"}` or `{"crawler": "search_gov_spiders"}` at the end of log messages but now you should see:

```
{
    "spider": {
        "name": "domain_spider",
        "allowed_domains": "example.com",
        "starting_urls": "https://www.example.com"
    }
}
OR
{
    "crawler": {
        "name": "search_gov_spiders"
    }
}
```

### How to Test
Run a spider e.g. `scrapy crawl domain_spider -a allowed_domains=quotes.toscrape.com -a start_urls=https://quotes.toscrape.com/` and verify the following:
* Speed of requests, as reported in the logs, is limited to a maximum of 1 page per second (60/min)
* No log messages printed about telnet starting
* While the spider is running, in another terminal run `ps aux | grep playwright`.  There should be no results.  Compare this to main to see the change.
* Ensure output correct and where expected
* Verify that logging messages specific to a spider or crawler contains a detailed spider or crawler object at the end of the log message as shown above.

Run a js spider e.g.`scrapy crawl domain_spider_js -a allowed_domains=quotes.toscrape.com -a start_urls=https://quotes.toscrape.com/js/`
* Ensure output correct and where expected
* Similar logging as above.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer".
