### PR TITLE
SRCH-5748-Update-Spider-FEEDS-Setting

### DIFF
--- a/search_gov_crawler/search_gov_spiders/pipelines.py
+++ b/search_gov_crawler/search_gov_spiders/pipelines.py
@@ -4,10 +4,9 @@ See: https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 """
 
 import os
+import threading
 from pathlib import Path
-
 from scrapy.exceptions import DropItem
-
 
 class SearchGovSpidersPipeline:
     """
@@ -23,27 +22,27 @@ class SearchGovSpidersPipeline:
         self.short_file = open(self.base_path_name, "w", encoding="utf-8")
         self.max_file_size = 3900
         self.paginate = True
+        self.lock = threading.Lock()
 
     def process_item(self, item, _spider):
         """Checks that the file is not at max size.
         Adds it to the file if less, or creates a new file if too large."""
+        with self.lock: 
+            line = item["url"]
+            self.current_file_size += 1
+            next_file_size = self.current_file_size + len(line)
+            if self.paginate and next_file_size > self.max_file_size:
+                self.short_file.close()
+                new_name = str(self.parent_file_path / f"output/all-links{self.file_number}.csv")
+                os.rename(self.base_path_name, new_name)
+                self.file_number = self.file_number + 1
+                self.short_file = open(self.base_path_name, "w", encoding="utf-8")
+                self.current_file_size = 0
 
-        line = item["url"]
-        self.current_file_size += 1
-        next_file_size = self.current_file_size + len(line)
-        if self.paginate and next_file_size > self.max_file_size:
-            self.short_file.close()
-            new_name = str(self.parent_file_path / f"output/all-links{self.file_number}.csv")
-            os.rename(self.base_path_name, new_name)
-            self.file_number = self.file_number + 1
-            self.short_file = open(self.base_path_name, "w", encoding="utf-8")
-            self.current_file_size = 0
-
-        self.short_file.write(line)
-        self.short_file.write("\n")
-        self.current_file_size = self.current_file_size + len(line)
-
-        return item
+            self.short_file.write(line)
+            self.short_file.write("\n")
+            self.current_file_size = self.current_file_size + len(line)
+            return item
 
 
 class DeDeuplicatorPipeline:

--- a/search_gov_crawler/search_gov_spiders/pipelines.py
+++ b/search_gov_crawler/search_gov_spiders/pipelines.py
@@ -4,7 +4,6 @@ See: https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 """
 
 import os
-import threading
 from pathlib import Path
 from scrapy.exceptions import DropItem
 import fcntl
@@ -19,36 +18,32 @@ class SearchGovSpidersPipeline:
         self.current_file_size = 0
         self.file_number = 1
         self.parent_file_path = Path(__file__).parent.parent.resolve()
-        self.base_path_name = str(self.parent_file_path / "output/all-links.csv")
+        self.base_path_name = str(self.parent_file_path / f"output/all-links-p{os.getpid()}.csv")
         self.short_file = open(self.base_path_name, "a", encoding="utf-8")
-        self.max_file_size = 3900
-        self.paginate = False
-        self.lock = threading.Lock()
-        self.line_number = 0
+        self.max_file_size = 39000000 #3.9MB max
+        self.paginate = True
 
     def process_item(self, item, _spider):
         """Checks that the file is not at max size.
         Adds it to the file if less, or creates a new file if too large."""
-        with self.lock: 
-            fcntl.flock(self.short_file.fileno(), fcntl.LOCK_EX)
-            line = item["url"]
-            self.line_number += 1
-            print(f'{self.line_number}) The line is: {line}')
-            self.current_file_size += 1
-            next_file_size = self.current_file_size + len(line)
-            if self.paginate and next_file_size > self.max_file_size:
-                self.short_file.close()
-                new_name = str(self.parent_file_path / f"output/all-links{self.file_number}.csv")
-                os.rename(self.base_path_name, new_name)
-                self.file_number = self.file_number + 1
-                self.short_file = open(self.base_path_name, "w", encoding="utf-8")
-                self.current_file_size = 0
-            self.short_file.write(line)
-            print(f'{self.line_number}) WRITTEN: The line is: {line}')
-            self.short_file.write("\n")
-            self.current_file_size = self.current_file_size + len(line)
-            fcntl.flock(self.short_file.fileno(), fcntl.LOCK_UN)
-            return item
+        fcntl.flock(self.short_file.fileno(), fcntl.LOCK_EX)
+        line = item["url"]
+        self.current_file_size += 1
+        file_stats = os.stat(self.base_path_name)
+        self.current_file_size += file_stats.st_size
+        next_file_size = self.current_file_size + len(line)
+        if self.paginate and next_file_size > self.max_file_size:
+            self.short_file.close()
+            new_name = str(self.parent_file_path / f"output/all-links-p{os.getpid()}-{self.file_number}.csv")
+            os.rename(self.base_path_name, new_name)
+            self.file_number = self.file_number + 1
+            self.short_file = open(self.base_path_name, "w", encoding="utf-8")
+            self.current_file_size = 0
+        self.short_file.write(line)
+        self.short_file.write("\n")
+        self.current_file_size = self.current_file_size + len(line)
+        fcntl.flock(self.short_file.fileno(), fcntl.LOCK_UN)
+        return item
 
 
 class DeDeuplicatorPipeline:

--- a/search_gov_crawler/search_gov_spiders/pipelines.py
+++ b/search_gov_crawler/search_gov_spiders/pipelines.py
@@ -6,7 +6,6 @@ See: https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 import os
 from pathlib import Path
 from scrapy.exceptions import DropItem
-import fcntl
 
 class SearchGovSpidersPipeline:
     """
@@ -26,7 +25,6 @@ class SearchGovSpidersPipeline:
     def process_item(self, item, _spider):
         """Checks that the file is not at max size.
         Adds it to the file if less, or creates a new file if too large."""
-        fcntl.flock(self.short_file.fileno(), fcntl.LOCK_EX)
         line = item["url"]
         self.current_file_size += 1
         file_stats = os.stat(self.base_path_name)
@@ -42,7 +40,6 @@ class SearchGovSpidersPipeline:
         self.short_file.write(line)
         self.short_file.write("\n")
         self.current_file_size = self.current_file_size + len(line)
-        fcntl.flock(self.short_file.fileno(), fcntl.LOCK_UN)
         return item
 
 

--- a/search_gov_crawler/search_gov_spiders/pipelines.py
+++ b/search_gov_crawler/search_gov_spiders/pipelines.py
@@ -7,6 +7,7 @@ import os
 import threading
 from pathlib import Path
 from scrapy.exceptions import DropItem
+import fcntl
 
 class SearchGovSpidersPipeline:
     """
@@ -19,16 +20,20 @@ class SearchGovSpidersPipeline:
         self.file_number = 1
         self.parent_file_path = Path(__file__).parent.parent.resolve()
         self.base_path_name = str(self.parent_file_path / "output/all-links.csv")
-        self.short_file = open(self.base_path_name, "w", encoding="utf-8")
+        self.short_file = open(self.base_path_name, "a", encoding="utf-8")
         self.max_file_size = 3900
-        self.paginate = True
+        self.paginate = False
         self.lock = threading.Lock()
+        self.line_number = 0
 
     def process_item(self, item, _spider):
         """Checks that the file is not at max size.
         Adds it to the file if less, or creates a new file if too large."""
         with self.lock: 
+            fcntl.flock(self.short_file.fileno(), fcntl.LOCK_EX)
             line = item["url"]
+            self.line_number += 1
+            print(f'{self.line_number}) The line is: {line}')
             self.current_file_size += 1
             next_file_size = self.current_file_size + len(line)
             if self.paginate and next_file_size > self.max_file_size:
@@ -38,10 +43,11 @@ class SearchGovSpidersPipeline:
                 self.file_number = self.file_number + 1
                 self.short_file = open(self.base_path_name, "w", encoding="utf-8")
                 self.current_file_size = 0
-
             self.short_file.write(line)
+            print(f'{self.line_number}) WRITTEN: The line is: {line}')
             self.short_file.write("\n")
             self.current_file_size = self.current_file_size + len(line)
+            fcntl.flock(self.short_file.fileno(), fcntl.LOCK_UN)
             return item
 
 

--- a/search_gov_crawler/search_gov_spiders/settings.py
+++ b/search_gov_crawler/search_gov_spiders/settings.py
@@ -98,13 +98,6 @@ HTTPCACHE_DIR = "httpcache"
 # Set settings whose default value is deprecated to a future-proof value
 REQUEST_FINGERPRINTER_IMPLEMENTATION = "2.7"
 TWISTED_REACTOR = "twisted.internet.asyncioreactor.AsyncioSelectorReactor"
-FEED_EXPORT_ENCODING = "utf-8"
-
-FEEDS = {
-    "scrapy_urls/%(name)s/%(name)s_%(time)s.txt": {
-        "format": "csv",
-    }
-}
 
 # Playwright Settings
 PLAYWRIGHT_BROWSER_TYPE = "chromium"

--- a/tests/search_gov_spiders/test_full_crawl.py
+++ b/tests/search_gov_spiders/test_full_crawl.py
@@ -2,7 +2,6 @@ import json
 import tempfile
 import sys
 from pathlib import Path
-import threading
 
 import pytest
 
@@ -102,7 +101,6 @@ def test_full_crawl(mock_scrapy_settings, monkeypatch, spider, use_dedup, crawl_
             pipeline_cls.short_file = open(pipeline_cls.base_path_name, "w", encoding="utf-8")
             pipeline_cls.max_file_size = 3900
             pipeline_cls.paginate = True
-            pipeline_cls.lock = threading.Lock()
 
         monkeypatch.setattr(
             "search_gov_crawler.search_gov_spiders.pipelines.SearchGovSpidersPipeline.__init__", mock_init

--- a/tests/search_gov_spiders/test_full_crawl.py
+++ b/tests/search_gov_spiders/test_full_crawl.py
@@ -2,6 +2,7 @@ import json
 import tempfile
 import sys
 from pathlib import Path
+import threading
 
 import pytest
 
@@ -101,6 +102,7 @@ def test_full_crawl(mock_scrapy_settings, monkeypatch, spider, use_dedup, crawl_
             pipeline_cls.short_file = open(pipeline_cls.base_path_name, "w", encoding="utf-8")
             pipeline_cls.max_file_size = 3900
             pipeline_cls.paginate = True
+            pipeline_cls.lock = threading.Lock()
 
         monkeypatch.setattr(
             "search_gov_crawler.search_gov_spiders.pipelines.SearchGovSpidersPipeline.__init__", mock_init


### PR DESCRIPTION
## Summary
We needed to disable to feed exporter (to do this just remove it from the settings.py) so that when the spiders run in parallel the extra file is not written to superfluously. 

Added file lock for writing to the all-links Item pipeline. 

Each spider will write to it's own all-links csv (which means each job has it's own file). Many spiders will not hit the 3.9MB limit but this will allow future work to immediately send the results (completed csv file) as the spider/job closes without waiting for the file to fill up for a new spider to populate it.  

#### Testing 
When you run a benchmark test make sure no file is being written to search_gov_crawler/scrapy_urls/domain_spider or search_gov_crawler/scrapy_urls/domain_spider_js. Only the all-links csvs should be created now. 

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".
