### PR TITLE
SRCH-5745 Scheduler Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The home for the spider that supports search.gov.
   * [Running Against A Specific Domain](#running-against-a-specific-domain)
 * [Setup and Use](#setup-and-use)
   * [Option 1: command-line](#option-1-straight-from-command-line)
-  * [Option 2: server](#option-2-deploying-on-server-scrapyd)
+  * [Option 2: benchmark](#option-2-benchmark-command-line)
+  * [Option 3: custom scheduler](#option-3-custom-scheduler)
+  * [Option 4: scrapyd](#option-2-deploying-on-server-scrapyd)
 * [Adding New Spiders](#adding-new-spiders)
 * [Running Scrapydweb UI](#running-scrapydweb-ui)
 
@@ -84,18 +86,32 @@ Make sure to run `pip install -r requirements.txt` and `playwright install` befo
 
           $ scrapy runspider <spider_file.py>  -o <filepath_to_output_folder/spider_output_filename.csv>
 
-### Option 2: deploying on server (Scrapyd)
-1. First, install Scrapyd and scrapyd-client (library that helps eggify and deploy the Scrapy project to the Scrapyd server):
+### Option 2: benchmark command line
+The benchmark script is primarily intended for use in timing and testing scrapy runs.  There are two ways to run.  In either case its
+likes you want to redirect your ouput to a log file using something like `<benchmark command> >scrapy.log 2>&1`
+1. To run a single domain (specifying starting URL `-u` and allowed domain `-d`):
 
-    *       $ pip install scrapyd
-    *       $ pip install git+https://github.com/scrapy/scrapyd-client.git
+          $ python search_gov_spiders/benchmark.py -u https://www.example.com -d example.com
 
-2. Next, navigate to the [*scrapyd_files*](search_gov_crawler/scrapyd_files) directory and start the server :
+2. To run multiple spiders simultaneously, provide a json file in the format of the [*crawl-sites.json file*](search_gov_crawler/search_gov_spiders/utility_files/crawl-sites.json) as an argument:
+
+          $ python search_gov_spiders/benchmark.py -f </path/to/crawl-sites-like-file.json>
+
+There are other options available.  Run `python search_gov_spiders/benchmark.py -h` for more info.
+
+### Option 3: custom scheduler
+1. To run jobs on a schedule, as defined in the [*crawl-sites.json file*](search_gov_crawler/search_gov_spiders/utility_files/crawl-sites.json)
+
+          $ python search_gov_spiders/scrapy_scheduler.py
+
+### Option 4: deploying on server (Scrapyd)
+1. Navigate to the [*Scrapy project root directory*](search_gov_crawler) and start the server.
 
         $ scrapyd
+
     * Note: the directory where you start the server is arbitrary. It's simply where the logs and Scrapy project FEED destination (relative to the server directory) will be.
 
-3. Navigate to the [*Scrapy project root directory*](search_gov_crawler) and run this command to eggify the Scrapy project and deploy it to the Scrapyd server:
+2. Run this command to eggify the Scrapy project and deploy it to the Scrapyd server:
 
         $ scrapyd-deploy default
 
@@ -123,7 +139,7 @@ Make sure to run `pip install -r requirements.txt` and `playwright install` befo
             # deploy production
             scrapyd-deploy production
 
-4. For an interface to view jobs (pending, running, finished) and logs, access http://localhost:6800/. However, to actually manipulate the spiders deployed to the Scrapyd server, you'll need to use the [*Scrapyd JSON API*](https://scrapyd.readthedocs.io/en/latest/api.html).
+3. For an interface to view jobs (pending, running, finished) and logs, access http://localhost:6800/. However, to actually manipulate the spiders deployed to the Scrapyd server, you'll need to use the [*Scrapyd JSON API*](https://scrapyd.readthedocs.io/en/latest/api.html).
 
     Some most-used commands:
 

--- a/search_gov_crawler/benchmark.py
+++ b/search_gov_crawler/benchmark.py
@@ -49,6 +49,7 @@ def init_scheduler() -> BackgroundScheduler:
     """
 
     max_workers = int(os.environ.get("SCRAPY_MAX_WORKERS", min(32, (os.cpu_count() or 1) + 4)))
+    log.info("Max workers for schedule set to %s", max_workers)
 
     return BackgroundScheduler(
         jobstores={"memory": MemoryJobStore()},
@@ -100,6 +101,8 @@ def benchmark_from_file(input_file: Path, runtime_offset_seconds: int):
         msg = f"Input file {input_file} does not exist!"
         raise FileNotFoundError(msg)
 
+    msg = "Starting benchmark from file! input_file=%s runtime_offset_seconds=%s"
+    log.info(msg, input_file.name, runtime_offset_seconds)
     crawl_sites = CrawlSites.from_file(file=input_file)
 
     scheduler = init_scheduler()

--- a/search_gov_crawler/benchmark.py
+++ b/search_gov_crawler/benchmark.py
@@ -19,7 +19,6 @@ Allow benchmarking and testing of spider.  Run this script in one of two ways:
 """
 
 import argparse
-import json
 import logging
 import os
 import sys
@@ -34,10 +33,12 @@ from pythonjsonlogger.json import JsonFormatter
 
 from search_gov_crawler import scrapy_scheduler
 from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
+from search_gov_crawler.search_gov_spiders.utility_files.crawl_sites import CrawlSites
 
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger()
-log.handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
+logging.basicConfig(level=os.environ.get("SCRAPY_LOG_LEVEL", "INFO"))
+logging.getLogger().handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
+
+log = logging.getLogger("search_gov_crawler.benchmark")
 
 
 def init_scheduler() -> BackgroundScheduler:
@@ -96,13 +97,17 @@ def benchmark_from_file(input_file: Path, runtime_offset_seconds: int):
     """
 
     if not input_file.exists():
-        raise FileNotFoundError(f"Input file {input_file} does not exist!")
+        msg = f"Input file {input_file} does not exist!"
+        raise FileNotFoundError(msg)
 
-    crawl_sites = json.loads(input_file.read_text(encoding="UTF-8"))
+    crawl_sites = CrawlSites.from_file(file=input_file)
 
     scheduler = init_scheduler()
     for crawl_site in crawl_sites:
-        apscheduler_job = create_apscheduler_job(runtime_offset_seconds=runtime_offset_seconds, **crawl_site)
+        apscheduler_job = create_apscheduler_job(
+            runtime_offset_seconds=runtime_offset_seconds,
+            **crawl_site.to_dict(exclude=("schedule",)),
+        )
         scheduler.add_job(
             **apscheduler_job,
             jobstore="memory",

--- a/search_gov_crawler/scrapy_scheduler.py
+++ b/search_gov_crawler/scrapy_scheduler.py
@@ -11,11 +11,11 @@ from apscheduler.triggers.cron import CronTrigger
 from pythonjsonlogger.json import JsonFormatter
 
 from search_gov_crawler.search_gov_spiders.extensions.json_logging import LOG_FMT
-from search_gov_crawler.search_gov_spiders.utility_files.init_schedule import SpiderSchedule
+from search_gov_crawler.search_gov_spiders.utility_files.crawl_sites import CrawlSites
 
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger()
-log.handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
+logging.basicConfig(level=os.environ.get("SCRAPY_LOG_LEVEL", "INFO"))
+logging.getLogger().handlers[0].setFormatter(JsonFormatter(fmt=LOG_FMT))
+log = logging.getLogger("search_gov_crawler.scrapy_scheduler")
 
 CRAWL_SITES_FILE = Path(__file__).parent / "search_gov_spiders" / "utility_files" / "crawl-sites.json"
 
@@ -41,39 +41,29 @@ def run_scrapy_crawl(spider: str, allow_query_string: bool, allowed_domains: str
     log.info(msg, spider, allow_query_string, allowed_domains, start_urls)
 
 
-def transform_crawl_sites(crawl_sites: list[dict]) -> list[dict]:
-    """Transform crawl sites records into a format that can be used to"""
+def transform_crawl_sites(crawl_sites: CrawlSites) -> list[dict]:
+    """
+    Transform crawl sites records into a format that can be used to create apscheduler jobs.  Only
+    scheduler jobs that have a value for the `schedule` field.
+    """
 
     transformed_crawl_sites = []
-    schedule = SpiderSchedule()
 
-    for crawl_site in crawl_sites:
-        job_name = str(crawl_site["name"])
-        schedule_slot = schedule.get_next_slot()
+    for crawl_site in crawl_sites.scheduled():
+        job_name = crawl_site.name
         transformed_crawl_sites.append(
             {
                 "func": run_scrapy_crawl,
                 "id": job_name.lower().replace(" ", "-").replace("---", "-"),
                 "name": job_name,
-                "trigger": CronTrigger(
-                    year="*",
-                    month="*",
-                    day="*",
-                    week="*",
-                    day_of_week=schedule_slot.day,
-                    hour=schedule_slot.hour,
-                    minute=schedule_slot.minute,
-                    second=0,
-                    timezone="UTC",
-                    jitter=0,
-                ),
+                "trigger": CronTrigger.from_crontab(expr=crawl_site.schedule, timezone="UTC"),
                 "args": [
-                    "domain_spider" if not crawl_site["handle_javascript"] else "domain_spider_js",
-                    crawl_site["allow_query_string"],
-                    crawl_site["allowed_domains"],
-                    crawl_site["starting_urls"],
+                    "domain_spider" if not crawl_site.handle_javascript else "domain_spider_js",
+                    crawl_site.allow_query_string,
+                    crawl_site.allowed_domains,
+                    crawl_site.starting_urls,
                 ],
-            }
+            },
         )
 
     return transformed_crawl_sites
@@ -83,11 +73,12 @@ def start_scrapy_scheduler(input_file: Path) -> None:
     """Initializes schedule from input file, schedules jobs and runs scheduler"""
 
     # Load and transform crawl sites
-    crawl_sites = json.loads(input_file.read_text(encoding="UTF-8"))
+    crawl_sites = CrawlSites.from_file(file=input_file)
     apscheduler_jobs = transform_crawl_sites(crawl_sites)
 
-    # Initalize scheduler
-    max_workers = min(32, (os.cpu_count() or 1) + 4)  # default from concurrent.futures
+    # Initalize scheduler - 'min(32, (os.cpu_count() or 1) + 4)' is default from concurrent.futures
+    max_workers = int(os.environ.get("SCRAPY_MAX_WORKERS", min(32, (os.cpu_count() or 1) + 4)))
+    log.info("Max workers for schedule set to %s", max_workers)
 
     scheduler = BlockingScheduler(
         jobstores={"memory": MemoryJobStore()},

--- a/search_gov_crawler/scrapy_scheduler.py
+++ b/search_gov_crawler/scrapy_scheduler.py
@@ -77,7 +77,8 @@ def start_scrapy_scheduler(input_file: Path) -> None:
     apscheduler_jobs = transform_crawl_sites(crawl_sites)
 
     # Initalize scheduler - 'min(32, (os.cpu_count() or 1) + 4)' is default from concurrent.futures
-    max_workers = int(os.environ.get("SCRAPY_MAX_WORKERS", min(32, (os.cpu_count() or 1) + 4)))
+    # but set to default of 5 to ensure consistent numbers between environments and for schedule
+    max_workers = int(os.environ.get("SCRAPY_MAX_WORKERS", "5"))
     log.info("Max workers for schedule set to %s", max_workers)
 
     scheduler = BlockingScheduler(

--- a/search_gov_crawler/search_gov_spiders/utility_files/crawl-sites.json
+++ b/search_gov_crawler/search_gov_spiders/utility_files/crawl-sites.json
@@ -4,6 +4,7 @@
         "allow_query_string": false,
         "allowed_domains": "armymwr.com",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.armymwr.com/"
     },
     {
@@ -11,6 +12,7 @@
         "allow_query_string": false,
         "allowed_domains": "travel.dod.mil",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.travel.dod.mil/"
     },
     {
@@ -18,6 +20,7 @@
         "allow_query_string": false,
         "allowed_domains": "ais.usvisa-info.com",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://ais.usvisa-info.com/"
     },
     {
@@ -25,6 +28,7 @@
         "allow_query_string": false,
         "allowed_domains": "toolkit.climate.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://toolkit.climate.gov"
     },
     {
@@ -32,6 +36,7 @@
         "allow_query_string": false,
         "allowed_domains": "oha.ed.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://oha.ed.gov"
     },
     {
@@ -39,6 +44,7 @@
         "allow_query_string": false,
         "allowed_domains": "accessdata.fda.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.accessdata.fda.gov/CMS_IA/default.html"
     },
     {
@@ -46,6 +52,7 @@
         "allow_query_string": false,
         "allowed_domains": "drive.hhs.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://drive.hhs.gov/"
     },
     {
@@ -53,6 +60,7 @@
         "allow_query_string": false,
         "allowed_domains": "allhands.navy.mil",
         "handle_javascript": true,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://allhands.navy.mil/"
     },
     {
@@ -60,6 +68,7 @@
         "allow_query_string": false,
         "allowed_domains": "mynavyhr.navy.mil",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.mynavyhr.navy.mil/"
     },
     {
@@ -67,6 +76,7 @@
         "allow_query_string": false,
         "allowed_domains": "diversity.nih.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://diversity.nih.gov/"
     },
     {
@@ -74,6 +84,7 @@
         "allow_query_string": false,
         "allowed_domains": "lrp.nih.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.lrp.nih.gov/"
     },
     {
@@ -81,6 +92,7 @@
         "allow_query_string": false,
         "allowed_domains": "orwh.od.nih.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://orwh.od.nih.gov/"
     },
     {
@@ -88,6 +100,7 @@
         "allow_query_string": false,
         "allowed_domains": "coastwatch.noaa.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://coastwatch.noaa.gov/cw/index.html"
     },
     {
@@ -95,6 +108,7 @@
         "allow_query_string": false,
         "allowed_domains": "eastcoast.coastwatch.noaa.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://eastcoast.coastwatch.noaa.gov/"
     },
     {
@@ -102,6 +116,7 @@
         "allow_query_string": false,
         "allowed_domains": "coastwatch.glerl.noaa.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://coastwatch.glerl.noaa.gov/"
     },
     {
@@ -109,6 +124,7 @@
         "allow_query_string": false,
         "allowed_domains": "coastwatch.pfeg.noaa.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://coastwatch.pfeg.noaa.gov/"
     },
     {
@@ -116,6 +132,7 @@
         "allow_query_string": false,
         "allowed_domains": "goes-r.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.goes-r.gov"
     },
     {
@@ -123,6 +140,7 @@
         "allow_query_string": false,
         "allowed_domains": "fincen.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.fincen.gov/"
     },
     {
@@ -130,6 +148,7 @@
         "allow_query_string": false,
         "allowed_domains": "cacb.uscourts.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.cacb.uscourts.gov"
     },
     {
@@ -137,6 +156,7 @@
         "allow_query_string": false,
         "allowed_domains": "are.uscourts.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.are.uscourts.gov/"
     },
     {
@@ -144,6 +164,7 @@
         "allow_query_string": false,
         "allowed_domains": "caep.uscourts.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.caep.uscourts.gov/"
     },
     {
@@ -151,6 +172,7 @@
         "allow_query_string": false,
         "allowed_domains": "jpml.uscourts.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.jpml.uscourts.gov"
     },
     {
@@ -158,6 +180,7 @@
         "allow_query_string": false,
         "allowed_domains": "msnd.uscourts.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.msnd.uscourts.gov/"
     },
     {
@@ -165,6 +188,7 @@
         "allow_query_string": false,
         "allowed_domains": "mssd.uscourts.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.mssd.uscourts.gov/"
     },
     {
@@ -172,6 +196,7 @@
         "allow_query_string": false,
         "allowed_domains": "ncwba.uscourts.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.ncwba.uscourts.gov/"
     },
     {
@@ -179,6 +204,7 @@
         "allow_query_string": false,
         "allowed_domains": "pawd.uscourts.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.pawd.uscourts.gov/"
     },
     {
@@ -186,6 +212,7 @@
         "allow_query_string": false,
         "allowed_domains": "utb.uscourts.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.utb.uscourts.gov/"
     },
     {
@@ -193,6 +220,7 @@
         "allow_query_string": false,
         "allowed_domains": "fpacbc.usda.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.fpacbc.usda.gov/index.html"
     },
     {
@@ -200,6 +228,7 @@
         "allow_query_string": false,
         "allowed_domains": "help.nfc.usda.gov",
         "handle_javascript": true,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://help.nfc.usda.gov/"
     },
     {
@@ -207,6 +236,7 @@
         "allow_query_string": false,
         "allowed_domains": "accesstocare.va.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.accesstocare.va.gov"
     },
     {
@@ -214,6 +244,7 @@
         "allow_query_string": false,
         "allowed_domains": "benefits.va.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://benefits.va.gov/benefits/"
     },
     {
@@ -221,6 +252,7 @@
         "allow_query_string": false,
         "allowed_domains": "cfm.va.gov/til/",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.cfm.va.gov/til/"
     },
     {
@@ -228,6 +260,7 @@
         "allow_query_string": false,
         "allowed_domains": "cider.research.va.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.cider.research.va.gov"
     },
     {
@@ -235,6 +268,7 @@
         "allow_query_string": true,
         "allowed_domains": "herc.research.va.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.herc.research.va.gov/"
     },
     {
@@ -242,6 +276,7 @@
         "allow_query_string": false,
         "allowed_domains": "hsrd.research.va.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.hsrd.research.va.gov/"
     },
     {
@@ -249,6 +284,7 @@
         "allow_query_string": false,
         "allowed_domains": "myhealth.va.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.myhealth.va.gov"
     },
     {
@@ -256,6 +292,7 @@
         "allow_query_string": false,
         "allowed_domains": "va.gov/accountability/",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.va.gov/accountability/"
     },
     {
@@ -263,6 +300,7 @@
         "allow_query_string": false,
         "allowed_domains": "queri.research.va.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.queri.research.va.gov/"
     },
     {
@@ -270,6 +308,7 @@
         "allow_query_string": false,
         "allowed_domains": "research.va.gov",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.research.va.gov/"
     },
     {
@@ -277,6 +316,7 @@
         "allow_query_string": false,
         "allowed_domains": "va.gov/resources/",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.va.gov/resources/"
     },
     {
@@ -284,6 +324,7 @@
         "allow_query_string": false,
         "allowed_domains": "dantes.mil",
         "handle_javascript": false,
+        "schedule": "00 14 * * MON",
         "starting_urls": "https://www.dantes.mil/"
     }
 ]

--- a/search_gov_crawler/search_gov_spiders/utility_files/crawl-sites.json
+++ b/search_gov_crawler/search_gov_spiders/utility_files/crawl-sites.json
@@ -4,7 +4,7 @@
         "allow_query_string": false,
         "allowed_domains": "armymwr.com",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 08 * * MON",
         "starting_urls": "https://www.armymwr.com/"
     },
     {
@@ -12,7 +12,7 @@
         "allow_query_string": false,
         "allowed_domains": "travel.dod.mil",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.travel.dod.mil/"
     },
     {
@@ -20,7 +20,7 @@
         "allow_query_string": false,
         "allowed_domains": "ais.usvisa-info.com",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://ais.usvisa-info.com/"
     },
     {
@@ -28,7 +28,7 @@
         "allow_query_string": false,
         "allowed_domains": "toolkit.climate.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://toolkit.climate.gov"
     },
     {
@@ -36,7 +36,7 @@
         "allow_query_string": false,
         "allowed_domains": "oha.ed.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://oha.ed.gov"
     },
     {
@@ -44,7 +44,7 @@
         "allow_query_string": false,
         "allowed_domains": "accessdata.fda.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.accessdata.fda.gov/CMS_IA/default.html"
     },
     {
@@ -52,7 +52,7 @@
         "allow_query_string": false,
         "allowed_domains": "drive.hhs.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://drive.hhs.gov/"
     },
     {
@@ -60,7 +60,7 @@
         "allow_query_string": false,
         "allowed_domains": "allhands.navy.mil",
         "handle_javascript": true,
-        "schedule": "00 14 * * MON",
+        "schedule": "00 06 * * MON",
         "starting_urls": "https://allhands.navy.mil/"
     },
     {
@@ -68,7 +68,7 @@
         "allow_query_string": false,
         "allowed_domains": "mynavyhr.navy.mil",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.mynavyhr.navy.mil/"
     },
     {
@@ -76,7 +76,7 @@
         "allow_query_string": false,
         "allowed_domains": "diversity.nih.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://diversity.nih.gov/"
     },
     {
@@ -84,7 +84,7 @@
         "allow_query_string": false,
         "allowed_domains": "lrp.nih.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.lrp.nih.gov/"
     },
     {
@@ -92,7 +92,7 @@
         "allow_query_string": false,
         "allowed_domains": "orwh.od.nih.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://orwh.od.nih.gov/"
     },
     {
@@ -100,7 +100,7 @@
         "allow_query_string": false,
         "allowed_domains": "coastwatch.noaa.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 08 * * MON",
         "starting_urls": "https://coastwatch.noaa.gov/cw/index.html"
     },
     {
@@ -108,7 +108,7 @@
         "allow_query_string": false,
         "allowed_domains": "eastcoast.coastwatch.noaa.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 08 * * MON",
         "starting_urls": "https://eastcoast.coastwatch.noaa.gov/"
     },
     {
@@ -116,7 +116,7 @@
         "allow_query_string": false,
         "allowed_domains": "coastwatch.glerl.noaa.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://coastwatch.glerl.noaa.gov/"
     },
     {
@@ -124,7 +124,7 @@
         "allow_query_string": false,
         "allowed_domains": "coastwatch.pfeg.noaa.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://coastwatch.pfeg.noaa.gov/"
     },
     {
@@ -132,7 +132,7 @@
         "allow_query_string": false,
         "allowed_domains": "goes-r.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.goes-r.gov"
     },
     {
@@ -140,7 +140,7 @@
         "allow_query_string": false,
         "allowed_domains": "fincen.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.fincen.gov/"
     },
     {
@@ -148,7 +148,7 @@
         "allow_query_string": false,
         "allowed_domains": "cacb.uscourts.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.cacb.uscourts.gov"
     },
     {
@@ -156,7 +156,7 @@
         "allow_query_string": false,
         "allowed_domains": "are.uscourts.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.are.uscourts.gov/"
     },
     {
@@ -164,7 +164,7 @@
         "allow_query_string": false,
         "allowed_domains": "caep.uscourts.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.caep.uscourts.gov/"
     },
     {
@@ -172,7 +172,7 @@
         "allow_query_string": false,
         "allowed_domains": "jpml.uscourts.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.jpml.uscourts.gov"
     },
     {
@@ -180,7 +180,7 @@
         "allow_query_string": false,
         "allowed_domains": "msnd.uscourts.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.msnd.uscourts.gov/"
     },
     {
@@ -188,7 +188,7 @@
         "allow_query_string": false,
         "allowed_domains": "mssd.uscourts.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.mssd.uscourts.gov/"
     },
     {
@@ -196,7 +196,7 @@
         "allow_query_string": false,
         "allowed_domains": "ncwba.uscourts.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.ncwba.uscourts.gov/"
     },
     {
@@ -204,7 +204,7 @@
         "allow_query_string": false,
         "allowed_domains": "pawd.uscourts.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.pawd.uscourts.gov/"
     },
     {
@@ -212,7 +212,7 @@
         "allow_query_string": false,
         "allowed_domains": "utb.uscourts.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.utb.uscourts.gov/"
     },
     {
@@ -220,7 +220,7 @@
         "allow_query_string": false,
         "allowed_domains": "fpacbc.usda.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.fpacbc.usda.gov/index.html"
     },
     {
@@ -228,7 +228,7 @@
         "allow_query_string": false,
         "allowed_domains": "help.nfc.usda.gov",
         "handle_javascript": true,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 07 * * MON",
         "starting_urls": "https://help.nfc.usda.gov/"
     },
     {
@@ -236,7 +236,7 @@
         "allow_query_string": false,
         "allowed_domains": "accesstocare.va.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.accesstocare.va.gov"
     },
     {
@@ -244,7 +244,7 @@
         "allow_query_string": false,
         "allowed_domains": "benefits.va.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 08 * * MON",
         "starting_urls": "https://benefits.va.gov/benefits/"
     },
     {
@@ -252,7 +252,7 @@
         "allow_query_string": false,
         "allowed_domains": "cfm.va.gov/til/",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.cfm.va.gov/til/"
     },
     {
@@ -260,7 +260,7 @@
         "allow_query_string": false,
         "allowed_domains": "cider.research.va.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.cider.research.va.gov"
     },
     {
@@ -268,7 +268,7 @@
         "allow_query_string": true,
         "allowed_domains": "herc.research.va.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.herc.research.va.gov/"
     },
     {
@@ -276,7 +276,7 @@
         "allow_query_string": false,
         "allowed_domains": "hsrd.research.va.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.hsrd.research.va.gov/"
     },
     {
@@ -284,15 +284,15 @@
         "allow_query_string": false,
         "allowed_domains": "myhealth.va.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.myhealth.va.gov"
     },
     {
-        "name": "VA Offica of Accountability and Whistleblower Protection",
+        "name": "VA Office of Accountability and Whistleblower Protection",
         "allow_query_string": false,
         "allowed_domains": "va.gov/accountability/",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.va.gov/accountability/"
     },
     {
@@ -300,7 +300,7 @@
         "allow_query_string": false,
         "allowed_domains": "queri.research.va.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.queri.research.va.gov/"
     },
     {
@@ -308,7 +308,7 @@
         "allow_query_string": false,
         "allowed_domains": "research.va.gov",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 08 * * MON",
         "starting_urls": "https://www.research.va.gov/"
     },
     {
@@ -316,7 +316,7 @@
         "allow_query_string": false,
         "allowed_domains": "va.gov/resources/",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.va.gov/resources/"
     },
     {
@@ -324,7 +324,7 @@
         "allow_query_string": false,
         "allowed_domains": "dantes.mil",
         "handle_javascript": false,
-        "schedule": "00 14 * * MON",
+        "schedule": "30 09 * * MON",
         "starting_urls": "https://www.dantes.mil/"
     }
 ]

--- a/search_gov_crawler/search_gov_spiders/utility_files/crawl_sites.py
+++ b/search_gov_crawler/search_gov_spiders/utility_files/crawl_sites.py
@@ -1,0 +1,81 @@
+import json
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Self
+
+
+@dataclass
+class CrawlSite:
+    """
+    Represents a single crawl site record.  All fields required except schedule.
+    In normal operations, When schedule is blank, a job will not be scheduled.  When running
+    a benchmark, schedule is ignored.
+    """
+
+    name: str
+    allow_query_string: bool
+    allowed_domains: str
+    handle_javascript: bool
+    starting_urls: str
+    schedule: str | None = None
+
+    def __post_init__(self):
+        """Perform validation on record"""
+        # check required fields
+        missing_field_names = []
+        for field in fields(self):
+            if field.name == "schedule":
+                pass
+            elif getattr(self, field.name) is None:
+                missing_field_names.append(field.name)
+
+        if missing_field_names:
+            msg = f"All CrawlSite fields are required!  Add values for {",".join(missing_field_names)}"
+            raise TypeError(msg)
+
+        # check types
+        for field in fields(self):
+            if not isinstance(getattr(self, field.name), field.type):
+                msg = (
+                    f"Invalid type! Field {field.name} with value {getattr(self, field.name)} must be type {field.type}"
+                )
+                raise TypeError(msg)
+
+    def to_dict(self, *, exclude: tuple = ()) -> dict:
+        """Helper method to return dataclass as dictionary.  Exclude fields listed in exclude arg."""
+        crawl_site = asdict(self)
+        for field in exclude:
+            crawl_site.pop(field, None)
+
+        return crawl_site
+
+
+@dataclass
+class CrawlSites:
+    """Represents a single crawl site record"""
+
+    root: list[CrawlSite]
+
+    def __iter__(self):
+        """Iterate directly from CrawlSites instance instead of calling root."""
+        yield from self.root
+
+    def __post_init__(self):
+        """Perform validations on entire list"""
+
+        unique_sites = {(crawl_site.allowed_domains, crawl_site.starting_urls) for crawl_site in self.root}
+        if len(unique_sites) != len(self.root):
+            msg = "The combination of allowed_domain and starting_urls must be unique in file!"
+            raise TypeError(msg)
+
+    @classmethod
+    def from_file(cls, file: Path) -> Self:
+        """Create CrawlSites instance from file path to json input file"""
+
+        records = json.loads(file.read_text(encoding="UTF-8"))
+        crawl_sites = [CrawlSite(**record) for record in records]
+        return cls(crawl_sites)
+
+    def scheduled(self):
+        """Yield only records that have a schedule"""
+        yield from (crawl_site for crawl_site in self if crawl_site.schedule)

--- a/search_gov_crawler/search_gov_spiders/utility_files/import_plist.py
+++ b/search_gov_crawler/search_gov_spiders/utility_files/import_plist.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 import plistlib
-from datetime import datetime, date
+from datetime import date, datetime
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -78,6 +78,7 @@ def convert_plist_to_json(input_file: str, output_file: str, write_full_output: 
             "allow_query_string": False,
             "allowed_domains": create_allowed_domain(record["startingUrl"]),
             "handle_javascript": record["runJS"],
+            "schedule": None,
             "starting_urls": record["startingUrl"],
         }
         for record in transformed_scrutiny_records
@@ -89,6 +90,7 @@ def convert_plist_to_json(input_file: str, output_file: str, write_full_output: 
     search_gov_json_file = Path(__file__).parent / output_file
     with search_gov_json_file.open("w", encoding="UTF-8") as output:
         json.dump(final_search_gov_records, output, indent=4)
+        output.write("\n")
 
 
 if __name__ == "__main__":

--- a/tests/search_gov_spiders/conftest.py
+++ b/tests/search_gov_spiders/conftest.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from search_gov_crawler.search_gov_spiders.utility_files.crawl_sites import CrawlSites
+
 
 @pytest.fixture(name="crawl_sites_test_file")
 def fixture_crawl_sites_test_file() -> Path:
@@ -10,5 +12,10 @@ def fixture_crawl_sites_test_file() -> Path:
 
 
 @pytest.fixture(name="crawl_sites_test_file_json")
-def fixture_crawl_sites_test_file_json(crawl_sites_test_file):
+def fixture_crawl_sites_test_file_json(crawl_sites_test_file) -> dict:
     return json.loads(crawl_sites_test_file.resolve().read_text())
+
+
+@pytest.fixture(name="crawl_sites_test_file_dataclass")
+def fixture_crawl_sites_test_file_dataclass(crawl_sites_test_file) -> CrawlSites:
+    return CrawlSites.from_file(file=crawl_sites_test_file)

--- a/tests/search_gov_spiders/crawl-sites-test.json
+++ b/tests/search_gov_spiders/crawl-sites-test.json
@@ -4,6 +4,7 @@
         "allow_query_string": false,
         "allowed_domains": "quotes.toscrape.com",
         "handle_javascript": false,
+        "schedule": "0,15,30,45 * * * *",
         "starting_urls": "https://quotes.toscrape.com/"
     },
     {
@@ -11,6 +12,7 @@
         "allow_query_string": false,
         "allowed_domains": "quotes.toscrape.com",
         "handle_javascript": true,
+        "schedule": "0,15,30,45 * * * *",
         "starting_urls": "https://quotes.toscrape.com/js/"
     },
     {
@@ -18,6 +20,7 @@
         "allow_query_string": false,
         "allowed_domains": "quotes.toscrape.com",
         "handle_javascript": true,
+        "schedule": "0,15,30,45 * * * *",
         "starting_urls": "https://quotes.toscrape.com/js-delayed/"
     },
     {
@@ -25,6 +28,7 @@
         "allow_query_string": false,
         "allowed_domains": "quotes.toscrape.com/tag/",
         "handle_javascript": false,
+        "schedule": "0,15,30,45 * * * *",
         "starting_urls": "https://quotes.toscrape.com/"
     }
 ]

--- a/tests/search_gov_spiders/test_benchmark.py
+++ b/tests/search_gov_spiders/test_benchmark.py
@@ -1,0 +1,110 @@
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+import pytest
+from apscheduler.schedulers.blocking import BlockingScheduler
+from freezegun import freeze_time
+
+from search_gov_crawler import scrapy_scheduler
+from search_gov_crawler.benchmark import (
+    benchmark_from_args,
+    benchmark_from_file,
+    create_apscheduler_job,
+    init_scheduler,
+)
+
+
+@pytest.mark.parametrize(("scrapy_max_workers", "expected_val"), [("100", 100), (None, 14)])
+def test_init_scheduler(caplog, monkeypatch, scrapy_max_workers, expected_val):
+    if scrapy_max_workers:
+        monkeypatch.setenv("SCRAPY_MAX_WORKERS", scrapy_max_workers)
+    else:
+        monkeypatch.delenv("SCRAPY_MAX_WORKERS", raising=False)
+
+    monkeypatch.setattr(os, "cpu_count", lambda: 10)
+
+    with caplog.at_level("INFO"):
+        init_scheduler()
+
+    assert f"Max workers for schedule set to {expected_val}" in caplog.messages
+
+
+@freeze_time("2024-01-01 00:00:00", tz_offset=0)
+@pytest.mark.parametrize(("handle_javascript", "spider_arg"), [(True, "domain_spider_js"), (False, "domain_spider")])
+def test_create_apscheduler_job(handle_javascript, spider_arg):
+    test_args = {
+        "name": "test",
+        "allow_query_string": True,
+        "allowed_domains": "example.com",
+        "starting_urls": "https://www.example.com",
+        "handle_javascript": handle_javascript,
+        "runtime_offset_seconds": 5,
+    }
+
+    assert create_apscheduler_job(**test_args) == {
+        "func": scrapy_scheduler.run_scrapy_crawl,
+        "id": f"benchmark - {test_args['name']}",
+        "name": f"benchmark - {test_args['name']}",
+        "next_run_time": datetime(2024, 1, 1, 0, 0, 5, tzinfo=UTC),
+        "args": [
+            spider_arg,
+            test_args["allow_query_string"],
+            test_args["allowed_domains"],
+            test_args["starting_urls"],
+        ],
+    }
+
+
+class MockScheduler:
+    @staticmethod
+    def add_job(*_args, **_kwargs):
+        return True
+
+    @staticmethod
+    def start():
+        return True
+
+    @staticmethod
+    def shutdown():
+        return True
+
+
+def test_benchmark_from_args(caplog, monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda x: True)
+    monkeypatch.setattr("search_gov_crawler.benchmark.init_scheduler", lambda: MockScheduler())  # pylint: disable=unnecessary-lambda
+    test_args = {
+        "allow_query_string": True,
+        "allowed_domains": "unit-test.example.com",
+        "starting_urls": "https://unit-test.example.com",
+        "handle_javascript": False,
+        "runtime_offset_seconds": 0,
+    }
+    with caplog.at_level("INFO"):
+        benchmark_from_args(**test_args)
+
+    expected_log_msg = (
+        "Starting benchmark from args! "
+        "allow_query_string=True allowed_domains=unit-test.example.com starting_urls=https://unit-test.example.com "
+        "handle_javascript=False runtime_offset_seconds=0"
+    )
+    assert expected_log_msg in caplog.messages
+
+
+def test_benchmark_from_file(caplog, monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda x: True)
+    monkeypatch.setattr("search_gov_crawler.benchmark.init_scheduler", lambda: MockScheduler())  # pylint: disable=unnecessary-lambda
+
+    input_file = Path(__file__).parent / "crawl-sites-test.json"
+    with caplog.at_level("INFO"):
+        benchmark_from_file(input_file=input_file, runtime_offset_seconds=0)
+
+    assert "Starting benchmark from file! input_file=crawl-sites-test.json runtime_offset_seconds=0" in caplog.messages
+
+
+def test_benchmark_from_file_missing_file():
+    input_file = Path("/does/not/exist.json")
+    with pytest.raises(FileNotFoundError, match=f"Input file {input_file} does not exist!"):
+        benchmark_from_file(input_file=input_file, runtime_offset_seconds=0)

--- a/tests/search_gov_spiders/test_crawl_sites.py
+++ b/tests/search_gov_spiders/test_crawl_sites.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from search_gov_crawler.search_gov_spiders.utility_files.crawl_sites import CrawlSite, CrawlSites
@@ -100,3 +102,17 @@ def test_valid_crawl_sites_scheduled(base_crawl_site_args):
 def test_invalid_crawl_sites_duplicates(base_crawl_site_args):
     with pytest.raises(TypeError, match="The combination of allowed_domain and starting_urls must be unique in file!"):
         CrawlSites([CrawlSite(**base_crawl_site_args), CrawlSite(**base_crawl_site_args)])
+
+
+def test_crawl_sites_file_is_valid():
+    """
+    Read in the actual crawl-sites.json file and instantiate as a CrawlSites class.  This will run all built-in
+    validations and hopefully let you know if the file is invalid prior to attempting to run it in the scheduler.
+    Additionally, we are assuming that there is at least one scheduled job in the file.
+    """
+    crawl_sites_file = (
+        Path(__file__).parent.parent.parent / "search_gov_crawler/search_gov_spiders/utility_files/crawl-sites.json"
+    )
+
+    cs = CrawlSites.from_file(file=crawl_sites_file)
+    assert len(list(cs.scheduled())) > 0

--- a/tests/search_gov_spiders/test_crawl_sites.py
+++ b/tests/search_gov_spiders/test_crawl_sites.py
@@ -1,0 +1,102 @@
+import pytest
+
+from search_gov_crawler.search_gov_spiders.utility_files.crawl_sites import CrawlSite, CrawlSites
+
+
+@pytest.fixture(name="base_crawl_site_args")
+def fixture_base_crawl_site_args() -> dict:
+    return {
+        "name": "test",
+        "allow_query_string": True,
+        "allowed_domains": "example.com",
+        "handle_javascript": False,
+        "starting_urls": "https://www.example.com",
+    }
+
+
+@pytest.mark.parametrize("schedule", [None, "* * * * *"])
+def test_valid_crawl_site(schedule, base_crawl_site_args):
+    test_args = base_crawl_site_args
+    if schedule:
+        test_args["schedule"] = schedule
+
+    assert isinstance(CrawlSite(**test_args), CrawlSite)
+
+
+@pytest.mark.parametrize("exclude", [(), ("name",)])
+def test_crawl_site_to_dict(base_crawl_site_args, exclude):
+    cs = CrawlSite(**base_crawl_site_args)
+    output = cs.to_dict(exclude=exclude)
+    expected_output = base_crawl_site_args | {"schedule": None}
+
+    for field in exclude:
+        expected_output.pop(field)
+
+    assert isinstance(output, dict)
+    assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [("name",), ("allow_query_string",), ("allowed_domains",), ("handle_javascript", "starting_urls")],
+)
+def test_invalid_crawl_site_missing_field(fields, base_crawl_site_args):
+    test_args = base_crawl_site_args | {"schedule": "* * * * *"}
+
+    for field in fields:
+        test_args[field] = None
+
+    match = f"All CrawlSite fields are required!  Add values for {",".join(fields)}"
+    with pytest.raises(TypeError, match=match):
+        CrawlSite(**test_args)
+
+
+@pytest.mark.parametrize(
+    ("field", "new_value", "expected_type"),
+    [
+        ("name", 123, str),
+        ("allow_query_string", "string val", bool),
+        ("allowed_domains", True, str),
+        ("handle_javascript", 99.99, bool),
+        ("starting_urls", {"some": "dict"}, str),
+    ],
+)
+def test_invalid_crawl_site_wrong_type(base_crawl_site_args, field, new_value, expected_type):
+    test_args = base_crawl_site_args | {"schedule": "* * * * *"}
+    test_args[field] = new_value
+
+    match = f"Invalid type! Field {field} with value {new_value} must be type {expected_type}"
+    with pytest.raises(TypeError, match=match):
+        CrawlSite(**test_args)
+
+
+def test_valid_crawl_sites(base_crawl_site_args):
+    cs = CrawlSites([CrawlSite(**base_crawl_site_args)])
+
+    assert isinstance(cs.root, list)
+    assert isinstance(cs.root[0], CrawlSite)
+    assert list(cs.root) == list(cs)
+
+
+def test_valid_crawl_sites_from_file(crawl_sites_test_file):
+    cs = CrawlSites.from_file(file=crawl_sites_test_file)
+
+    assert len(list(cs)) == 4
+
+
+def test_valid_crawl_sites_scheduled(base_crawl_site_args):
+    different_crawl_site_args = base_crawl_site_args | {
+        "allowed_domains": "another.example.com",
+        "schedule": "* * * * *",
+        "starting_urls": "https://another.example.com",
+    }
+
+    test_input = [CrawlSite(**base_crawl_site_args), CrawlSite(**different_crawl_site_args)]
+
+    cs = CrawlSites(test_input)
+    assert len(list(cs.scheduled())) == 1
+
+
+def test_invalid_crawl_sites_duplicates(base_crawl_site_args):
+    with pytest.raises(TypeError, match="The combination of allowed_domain and starting_urls must be unique in file!"):
+        CrawlSites([CrawlSite(**base_crawl_site_args), CrawlSite(**base_crawl_site_args)])

--- a/tests/search_gov_spiders/test_deduplicator_pipeline.py
+++ b/tests/search_gov_spiders/test_deduplicator_pipeline.py
@@ -1,33 +1,42 @@
 import os
-import pytest
 from contextlib import suppress
 from unittest.mock import MagicMock, patch
+
+import pytest
 from scrapy.exceptions import DropItem
-from search_gov_crawler.search_gov_spiders.pipelines import (
-    SearchGovSpidersPipeline,
-    DeDeuplicatorPipeline,
-)
+
 from search_gov_crawler.search_gov_spiders.items import SearchGovSpidersItem
+from search_gov_crawler.search_gov_spiders.pipelines import (
+    DeDeuplicatorPipeline,
+    SearchGovSpidersPipeline,
+)
+
 # ---------------------------
 # Fixtures
 # ---------------------------
+
 
 @pytest.fixture
 def sample_item():
     """Fixture for a valid sample item."""
     return {"url": "http://example.com"}
 
+
 @pytest.fixture
 def invalid_item():
     """Fixture for an invalid item with no URL."""
     return {}
 
+
 @pytest.fixture
 def sample_spider():
     """Fixture for a mock spider with a logger."""
+
     class SpiderMock:
         logger = MagicMock()
+
     return SpiderMock()
+
 
 @pytest.fixture
 def pipeline_no_api():
@@ -35,20 +44,17 @@ def pipeline_no_api():
     with patch.dict(os.environ, {}, clear=True):
         return SearchGovSpidersPipeline()
 
-@pytest.fixture
-def pipeline_with_api():
-    """Fixture for SearchGovSpidersPipeline with SPIDER_URLS_API set."""
-    with patch.dict(os.environ, {"SPIDER_URLS_API": "http://mockapi.com"}):
-        return SearchGovSpidersPipeline()
 
 @pytest.fixture
 def deduplicator_pipeline():
     """Fixture for DeDeuplicatorPipeline with clean state."""
     return DeDeuplicatorPipeline()
 
+
 # ---------------------------
 # Tests for SearchGovSpidersPipeline
 # ---------------------------
+
 
 def test_missing_url_in_item(pipeline_no_api, sample_spider, invalid_item):
     """
@@ -57,9 +63,11 @@ def test_missing_url_in_item(pipeline_no_api, sample_spider, invalid_item):
     with pytest.raises(DropItem, match="Missing URL in item"):
         pipeline_no_api.process_item(invalid_item, sample_spider)
 
+
 # ---------------------------
 # Tests for DeDeuplicatorPipeline
 # ---------------------------
+
 
 @pytest.mark.parametrize(
     "item",
@@ -116,6 +124,7 @@ def test_deduplicator_pipeline_clean_state():
     # Second pipeline should also process the same item as it has a clean state
     result = pipeline2.process_item(item, None)
     assert result == item
+
 
 @pytest.mark.parametrize(
     ("items", "urls_seen_length"),

--- a/tests/search_gov_spiders/test_scrapy_scheduler.py
+++ b/tests/search_gov_spiders/test_scrapy_scheduler.py
@@ -20,69 +20,22 @@ def test_run_scrapy_crawl(caplog, monkeypatch):
     ) in caplog.messages
 
 
-def test_transform_crawl_sites(crawl_sites_test_file_json):
-    transformed_crawl_sites = transform_crawl_sites(crawl_sites_test_file_json)
+def test_transform_crawl_sites(crawl_sites_test_file_dataclass):
+    transformed_crawl_sites = transform_crawl_sites(crawl_sites_test_file_dataclass)
 
     # CronTrigger class does not implement __eq__
     triggers = [str(site.pop("trigger")) for site in transformed_crawl_sites]
-    assert triggers == [
-        str(
+    for trigger in triggers:
+        assert trigger == str(
             CronTrigger(
-                year="*",
                 month="*",
                 day="*",
-                week="*",
-                day_of_week="mon",
-                hour="03",
-                minute="30",
-                second=0,
+                day_of_week="*",
+                hour="*",
+                minute="0,15,30,45",
                 timezone="UTC",
-                jitter=0,
-            )
-        ),
-        str(
-            CronTrigger(
-                year="*",
-                month="*",
-                day="*",
-                week="*",
-                day_of_week="mon",
-                hour="05",
-                minute="30",
-                second=0,
-                timezone="UTC",
-                jitter=0,
-            )
-        ),
-        str(
-            CronTrigger(
-                year="*",
-                month="*",
-                day="*",
-                week="*",
-                day_of_week="mon",
-                hour="07",
-                minute="30",
-                second=0,
-                timezone="UTC",
-                jitter=0,
             ),
-        ),
-        str(
-            CronTrigger(
-                year="*",
-                month="*",
-                day="*",
-                week="*",
-                day_of_week="mon",
-                hour="09",
-                minute="30",
-                second=0,
-                timezone="UTC",
-                jitter=0,
-            ),
-        ),
-    ]
+        )
 
     assert transformed_crawl_sites == [
         {
@@ -118,5 +71,5 @@ def test_start_scrapy_scheduler(caplog, monkeypatch, crawl_sites_test_file):
     with caplog.at_level("INFO"):
         start_scrapy_scheduler(input_file=crawl_sites_test_file)
 
-    assert len(caplog.messages) == 4
+    assert len(caplog.messages) == 5
     assert "Adding job tentatively -- it will be properly scheduled when the scheduler starts" in caplog.messages

--- a/tests/search_gov_spiders/test_utiliity_files.py
+++ b/tests/search_gov_spiders/test_utiliity_files.py
@@ -113,6 +113,7 @@ def test_convert_plist_to_json(monkeypatch):
             "allow_query_string": False,
             "allowed_domains": "example.com",
             "handle_javascript": True,
+            "schedule": None,
             "starting_urls": "https://www.example.com/1",
         }
         assert len(full_output_records) == 5

--- a/tests/search_gov_spiders/test_utiliity_files.py
+++ b/tests/search_gov_spiders/test_utiliity_files.py
@@ -145,6 +145,8 @@ MANUAL_UPDATE_TEST_CASES = [
     ("https://www.cfm.va.gov/til/", "allowed_domains", "cfm.va.gov/til/"),
     ("https://www.va.gov/accountability/", "allowed_domains", "va.gov/accountability/"),
     ("https://www.va.gov/resources/", "allowed_domains", "va.gov/resources/"),
+    ("https://www.herc.research.va.gov/", "allow_query_string", True),
+    ("https://www.herc.research.va.gov/", "name", "VA HERC Research"),
 ]
 
 


### PR DESCRIPTION
## Summary
- Since the "naive" scheduler implemented in `search_gov_crawler/search_gov_spiders/utility_files/init_schedule.py` is not optimal for a polite spider, we need to design something else.  Additionally, I wanted it to be more flexible.  To that end I added a "schedule" field in the crawl-sites.json file that holds a cron expression that can be fed, as-is, into the scheduler.  A record will now look like:
```json
    {
        "name": "DOD Army MWR",
        "allow_query_string": false,
        "allowed_domains": "armymwr.com",
        "handle_javascript": false,
        "schedule": "00 14 * * MON",
        "starting_urls": "https://www.armymwr.com/"
    }
```
With each row defining when and how often that domain will run -- in this case every Monday at 2pm UTC.  We can make changes and redeploy as needed.  I added some dataclasses to help organize and validate this structure.
- I updated scrapy_scheduler.py and benchmark.py to use this functionality.
- I updated tests and also added tests for benchmark since they were missing.
- I updated the main README to describe this usage.
- I decided to just leave the old naive scheduler code in place for now.
- I also updated the plist import even though i don't really see us using it but I've been keeping it up to date all this time so why stop now?

### Initial Schedule
If you all have any feedback on this part especially, please let me know!  I looked at a few options and decided to start us off with a limit of 5 concurrent spider processes.  Sure we can do 50 but why? Given the lengths of some of the longer running jobs, we are just going to make things more complicated to debug if we have an error during the few minutes where 50 processes are running.  We can always adjust but also given what we don't know about the /urls endpoint I thought it best to be conservative.   Given this schedule we can finish everything (except NOAA Coastwatch which runs for at least a week) in 13ish hours.

We easily can change the limit with an environment variable and we can change the schedule in the crawl-sites.json file.

Because the JS sites take up so many resources, i put them both first and gave them ample time to finish before the nest job starts.  Then I scheduled the five longest running jobs and then all the rest.  As slots are opened up by jobs finishing, another job should start. I have estimates for all job run times [here](https://docs.google.com/spreadsheets/d/1PPx78a10I22EqeXNztqVIgzgK8T9WENcHhvlzYfNrSQ/edit?gid=0#gid=0).  I left an hour gap to ensure all the long running jobs have started (probably could have been five minutes) so that all the rest get queued properly. 

I just guessed on the start time (0600).  All times are in UTC.

0600 - Navy All Hands Magazine (JS site)
0730 - USDA NFC Help Documentation (JS Site)
0830 - Long running domains (DOD Army MWR, NOAA CoastWatch, NOAA CoastWatch East Coast Node, VA Benefits.va.gov, and VA Research & Development)
0930 - Rest of domains


### Testing
To test the scrapy_scheduler process, you can edit the craw-sites.json file and change one of the domains so that the schedule is a few minutes into the future -- if its 10:05 AM EST you can replace the schedule value with "07 15 * * *" for instance so that the particular domain will run at every day at 15:07 UTC or 10:07 EST and then run `python search_gov_crawler/scrapy_schedule.py`.  It will add all the domains to the scheduler and the one you changed should run when you expect.

You can also test the functionality with the benchmark process.  The easiest way is to just point the benchmark process to the crawl-sites-test.json file. Those domains are setup to run every 15 minutes, i.e. "0,15,30,45 * * * *".  To do this run `python search_gov_crawler/benchmark.py -f tests/search_gov_spiders/crawl-sites-test.json`

You should also verify the crawl-sites.json file to make sure the cron expressions match what I have described.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer".
